### PR TITLE
Fix ```toon syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,18 +837,18 @@ For output, be more explicit. When you want the model to **generate** TOON:
 
 Here's a prompt that works for both reading and generating:
 
-```
+````
 Data is in TOON format (2-space indent, arrays show length and fields).
 
-\`\`\`toon
+```toon
 users[3]{id,name,role,lastLogin}:
   1,Alice,admin,2025-01-15T10:30:00Z
   2,Bob,user,2025-01-14T15:22:00Z
   3,Charlie,user,2025-01-13T09:45:00Z
-\`\`\`
+```
 
 Task: Return only users with role "user" as TOON. Use the same header. Set [N] to match the row count. Output only the code block.
-```
+````
 
 > [!TIP]
 > For large uniform tables, use `encode(data, { delimiter: '\t' })` and tell the model "fields are tab-separated." Tabs often tokenize better than commas and reduce the need for quote-escaping.


### PR DESCRIPTION
This is much better 
<img width="1081" height="270" alt="image" src="https://github.com/user-attachments/assets/840200b8-25a1-4bdb-9f90-c41c7a3fffe5" />

vs 

<img width="851" height="237" alt="image" src="https://github.com/user-attachments/assets/9dc7b1e0-4e39-4353-898f-a58620ca5c82" />
