### PR TITLE
feat(cli): add `--stats` flag to show token savings

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,11 +493,15 @@ toon input.json
 | `--delimiter <char>` | Array delimiter: `,` (comma), `\t` (tab), `\|` (pipe) |
 | `--indent <number>` | Indentation size (default: `2`) |
 | `--length-marker` | Add `#` prefix to array lengths (e.g., `items[#3]`) |
+| `--stats` | Show token count estimates and savings (encode only) |
 | `--no-strict` | Disable strict validation when decoding |
 
 ### Examples
 
 ```bash
+# Show token savings when encoding
+toon data.json --stats -o output.toon
+
 # Tab-separated output (often more token-efficient)
 toon data.json --delimiter "\t" -o output.toon
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,5 +8,8 @@
   "dependencies": {
     "citty": "^0.1.6",
     "consola": "^3.4.2"
+  },
+  "devDependencies": {
+    "tokenx": "^1.2.0"
   }
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path'
 import process from 'node:process'
 import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
+import { estimateTokenCount } from 'tokenx'
 import { name, version } from '../../package.json' with { type: 'json' }
 import { decode, DEFAULT_DELIMITER, DELIMITERS, encode } from '../../src'
 
@@ -91,7 +92,7 @@ const main = defineCommand({
           delimiter: delimiter as Delimiter,
           indent,
           lengthMarker: args.lengthMarker === true ? '#' : false,
-          showStats: args.stats === true,
+          printStats: args.stats === true,
         })
       }
       else {
@@ -137,7 +138,7 @@ async function encodeToToon(config: {
   delimiter: Delimiter
   indent: number
   lengthMarker: NonNullable<EncodeOptions['lengthMarker']>
-  showStats: boolean
+  printStats: boolean
 }) {
   const jsonContent = await fsp.readFile(config.input, 'utf-8')
 
@@ -167,14 +168,15 @@ async function encodeToToon(config: {
     console.log(toonOutput)
   }
 
-  if (config.showStats) {
-    const jsonTokens = Math.ceil(jsonContent.length / 4)
-    const toonTokens = Math.ceil(toonOutput.length / 4)
+  if (config.printStats) {
+    const jsonTokens = estimateTokenCount(jsonContent)
+    const toonTokens = estimateTokenCount(toonOutput)
     const diff = jsonTokens - toonTokens
     const percent = ((diff / jsonTokens) * 100).toFixed(1)
 
-    consola.info(`\nToken estimate: ${jsonTokens} (JSON) → ${toonTokens} (TOON)`)
-    consola.success(`Saved ~${diff} tokens (${percent}%)`)
+    console.log()
+    consola.info(`Token estimates: ~${jsonTokens} (JSON) → ~${toonTokens} (TOON)`)
+    consola.success(`Saved ~${diff} tokens (-${percent}%)`)
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,10 @@ importers:
       consola:
         specifier: ^3.4.2
         version: 3.4.2
+    devDependencies:
+      tokenx:
+        specifier: ^1.2.0
+        version: 1.2.0
 
 packages:
 
@@ -2199,6 +2203,9 @@ packages:
   to-valid-identifier@1.0.0:
     resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
     engines: {node: '>=20'}
+
+  tokenx@1.2.0:
+    resolution: {integrity: sha512-x4bRrL23b22H+EqW2pbhIkkt3ouj27ZGmAS1QoIqpocEO4m0sAl2H1M4L1UzKqleikY4U9lz/TbEw4jeG8tm2A==}
 
   toml-eslint-parser@0.10.0:
     resolution: {integrity: sha512-khrZo4buq4qVmsGzS5yQjKe/WsFvV8fGfOjDQN0q4iy9FjRfPWRgTFrU8u1R2iu/SfWLhY9WnCi4Jhdrcbtg+g==}
@@ -4705,6 +4712,8 @@ snapshots:
     dependencies:
       '@sindresorhus/base62': 1.0.0
       reserved-identifiers: 1.2.0
+
+  tokenx@1.2.0: {}
 
   toml-eslint-parser@0.10.0:
     dependencies:


### PR DESCRIPTION
 ## Summary

  Added `--stats` flag to display token count comparison when encoding JSON to TOON.

  ## Usage

  ```bash
  toon data.json --stats
```
  ## Output:
  users[3]{id,name,role}:
    1,Alice,admin
    2,Bob,user
    3,Charlie,user

  ℹ Token estimate: 43 (JSON) → 18 (TOON)
  ✔ Saved ~25 tokens (58.1%)

  ## Implementation

  Uses simple approximation: `Math.ceil(text.length / 4)`
  (GPT-style tokenizers average ~4 chars per token)

  Why not use gpt-tokenizer:
  - Keeps CLI lightweight (no 2MB dependency)
  - Fast for quick feedback
  - Relative comparison is what matters here

  If you prefer accuracy over simplicity, I can switch to gpt-tokenizer.


  ## Screenshots

<img width="589" height="183" alt="image" src="https://github.com/user-attachments/assets/d0e6ac8d-9739-4f4c-bd7d-4795e08c7fb7" />

  ---
  Added a small feature that seemed useful. Hope you can accept this PR if it looks good to you!

  ---