### PR TITLE
docs: add contributing guide and code of conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[Bug] '
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. (commands or input)
+2. (expected / actual result)
+
+**Environment**
+- OS:
+- Node version:
+- pnpm/yarn/npm:
+
+**Additional context**
+Add any other context about the problem here.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code of Conduct
+
+This project follows the Contributor Covenant (version 3.0). We expect contributors to be respectful and inclusive.
+
+Summary
+- Be respectful and considerate in all communications.
+- Focus on what is best for the community.
+- Avoid harassing or discriminatory language or actions.
+
+Reporting
+
+If you experience or witness unacceptable behavior, please open an issue or contact the repository maintainers so we can address it. If you prefer private reporting, please use the contact method listed in the project's repository settings or reach out to the project owner.
+
+For the full text, see: https://www.contributor-covenant.org/version/3/0/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to TOON
+
+Thanks for helping improve TOON — small contributions make a big difference. This document gives a short, practical guide to getting started.
+
+## Quick start
+
+1. Fork the repository and create a feature branch from `main`:
+
+   git checkout -b my-fix-or-feature
+
+2. Install dependencies:
+
+   pnpm install
+
+3. Run tests:
+
+   pnpm test
+
+4. (Optional) Run lint or formatting if available in `package.json` scripts:
+
+   pnpm lint
+   pnpm format
+
+5. Run benchmarks (optional): see `benchmarks/README.md` for details.
+
+## What you can do
+
+- Fix typos and improve wording in `README.md` or `SPEC.md`.
+- Add or improve `benchmarks/` README and reproducibility notes.
+- Add small tests under `test/` for edge cases you find when reading the code.
+- Add issue templates, contributing docs, or a code of conduct (files in `.github/`).
+
+## Making a good pull request
+
+1. Use a descriptive branch name and commit message.
+2. Keep PRs small and focused — small changes are easier to review.
+3. In the PR description include:
+   - What you changed and why.
+   - How to run or test the change locally.
+   - Any related issue number (e.g. `#123`).
+4. If your change touches docs, update `README.md` or `SPEC.md` accordingly.
+
+## Tests & CI
+
+- Run the test suite locally before opening a PR: `pnpm test`.
+- If adding code, add a matching unit test in `test/` for the behavior you change.
+
+## Code style
+
+Follow the existing project conventions. If there is a lint script, run it locally.
+
+## Reporting bugs
+
+If you find a bug, open an issue using the provided bug report template in `.github/ISSUE_TEMPLATE/` (we provide a template in this repo).
+
+## Code of Conduct
+
+This project expects contributors to follow a Code of Conduct. See `CODE_OF_CONDUCT.md` for details.
+
+## Need help?
+
+- Open an issue and tag it `help wanted` or `good first issue`.
+- Open a draft PR if you want early feedback on a proposed change.
+
+Thank you for contributing — we appreciate your time and improvements!

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ TOON's sweet spot is **uniform arrays of objects** – multiple fields per row, 
 - [Notes and Limitations](#notes-and-limitations)
 - [Syntax Cheatsheet](#syntax-cheatsheet)
 - [Other Implementations](#other-implementations)
+- [Contributing](#contributing)
 
 ## Why TOON?
 
@@ -995,6 +996,12 @@ Task: Return only users with role "user" as TOON. Use the same header. Set [N] t
 - **Ruby:** [toon-ruby](https://github.com/andrepcg/toon-ruby)
 - **Rust:** [rtoon](https://github.com/shreyasbhat0/rtoon)
 - **Swift:** [TOONEncoder](https://github.com/mattt/TOONEncoder)
+
+## Contributing
+
+We welcome contributions! For a short, actionable guide to getting started (running tests, submitting a PR, and reporting issues) see `CONTRIBUTING.md` in the repository root. Also please review the `CODE_OF_CONDUCT.md` before contributing.
+
+If you're unsure where to start, look for issues labeled `good first issue` or `help wanted`, or open an issue to discuss a change before implementing it.
 
 ## License
 


### PR DESCRIPTION
This pull request introduces essential project documentation to support contributors and maintainers. The main additions include a contributing guide, a code of conduct, a bug report issue template, and updates to the `README.md` to reference these resources. These changes make it easier for new contributors to get started and ensure a welcoming and organized community.

**Documentation and Community Guidelines**

* Added a comprehensive `CONTRIBUTING.md` file with instructions for getting started, making pull requests, running tests, and reporting bugs.
* Added a `CODE_OF_CONDUCT.md` file outlining expected behavior and reporting procedures, following the Contributor Covenant v3.0.

**Issue Reporting**

* Added a bug report issue template at `.github/ISSUE_TEMPLATE/bug_report.md` to standardize bug submissions and improve reproducibility.

**README Updates**

* Added a "Contributing" section to the `README.md` with links and guidance for new contributors.
* Updated the table of contents in `README.md` to include the new "Contributing" section.