### PR TITLE
docs: add Clojure implementation to community implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,7 @@ Task: Return only users with role "user" as TOON. Use the same header. Set [N] t
 
 - **.NET:** [ToonSharp](https://github.com/0xZunia/ToonSharp)
 - **C++:** [ctoon](https://github.com/mohammadraziei/ctoon)
+- **Clojure:** [toon](https://github.com/vadelabs/toon)
 - **Crystal:** [toon-crystal](https://github.com/mamantoha/toon-crystal)
 - **Dart:** [toon](https://github.com/wisamidris77/toon)
 - **Elixir:** [toon_ex](https://github.com/kentaro/toon_ex)


### PR DESCRIPTION
Adds the Clojure implementation (https://github.com/vadelabs/toon) to the Community Implementations section in the README, maintaining alphabetical order.

The implementation is published on Clojars as `com.vadelabs/toon` and implements TOON v1.3 specification.