### PR TITLE
feat: add JSON flattening utility to improve TOON performance on nested data

### DIFF
--- a/packages/toon/src/encode/encoders.ts
+++ b/packages/toon/src/encode/encoders.ts
@@ -3,6 +3,7 @@ import { LIST_ITEM_MARKER } from '../constants'
 import { isArrayOfArrays, isArrayOfObjects, isArrayOfPrimitives, isJsonArray, isJsonObject, isJsonPrimitive } from './normalize'
 import { encodeAndJoinPrimitives, encodeKey, encodePrimitive, formatHeader } from './primitives'
 import { LineWriter } from './writer'
+import { flattenJson } from './flatten'
 
 // #region Encode normalized JsonValue
 
@@ -12,6 +13,11 @@ export function encodeValue(value: JsonValue, options: ResolvedEncodeOptions): s
   }
 
   const writer = new LineWriter(options.indent)
+
+  if (options.flatten) {
+    const maxDepth = options.flattenDepth ?? 3
+    value = flattenJson(value, maxDepth)
+  }
 
   if (isJsonArray(value)) {
     encodeArray(undefined, value, writer, 0, options)

--- a/packages/toon/src/encode/flatten.ts
+++ b/packages/toon/src/encode/flatten.ts
@@ -1,0 +1,65 @@
+import type { JsonValue, JsonObject } from '../types'
+import { isJsonArray, isJsonObject, isJsonPrimitive } from './normalize'
+
+
+/**
+ * Recursively flattens a JSON object or array into a single-level object.
+ *
+ * @param value - The JSON object or array to flatten.
+ * @param parentKey - The key to use as the prefix for the current level of flattening. Defaults to an empty string.
+ * @param delimiter - The delimiter to use when combining parent keys and child keys. Defaults to '.'.
+ * @returns A single-level object containing all the keys and values from the input JSON object or array.
+ */
+export function flattenJson(
+  value: JsonValue,
+  maxDepth = 3,
+  currentDepth = 0,
+  parentKey = '',
+  delimiter = '.',
+): JsonObject {
+  const result: JsonObject = {}
+
+  if (isJsonPrimitive(value)) {
+    if (parentKey) result[parentKey] = value
+    return result
+  }
+
+  if (isJsonArray(value)) {
+    value.forEach((item, i) => {
+      const key = parentKey ? `${parentKey}${delimiter}${i}` : String(i)
+      if (currentDepth < maxDepth)
+        Object.assign(result, flattenJson(item, maxDepth, currentDepth + 1, key, delimiter))
+      else
+        result[key] = item
+    })
+    return result
+  }
+
+  if (isJsonObject(value)) {
+    for (const [k, v] of Object.entries(value)) {
+      const key = parentKey ? `${parentKey}${delimiter}${k}` : k
+      if (currentDepth < maxDepth)
+        Object.assign(result, flattenJson(v, maxDepth, currentDepth + 1, key, delimiter))
+      else
+        result[key] = v
+    }
+  }
+
+  return result
+}
+
+
+/**
+ * Checks if a given JSON value is deeply nested, i.e., it contains a nested
+ * object or array at least 3 levels deep.
+ *
+ * @param value - The JSON value to check for deep nesting.
+ * @param depth - The current depth of the value. Defaults to 0.
+ * @returns `true` if the value is deeply nested, `false` otherwise.
+ */
+export function isDeeplyNested(value: JsonValue, depth = 0): boolean {
+  if (depth > 2) return true
+  if (isJsonArray(value)) return value.some(i => isDeeplyNested(i, depth + 1))
+  if (isJsonObject(value)) return Object.values(value).some(v => isDeeplyNested(v, depth + 1))
+  return false
+}

--- a/packages/toon/src/index.ts
+++ b/packages/toon/src/index.ts
@@ -42,6 +42,8 @@ function resolveOptions(options?: EncodeOptions): ResolvedEncodeOptions {
     indent: options?.indent ?? 2,
     delimiter: options?.delimiter ?? DEFAULT_DELIMITER,
     lengthMarker: options?.lengthMarker ?? false,
+    flatten: options?.flatten ?? false,
+    flattenDepth: options?.flattenDepth ?? 3,
   }
 }
 

--- a/packages/toon/src/types.ts
+++ b/packages/toon/src/types.ts
@@ -30,6 +30,18 @@ export interface EncodeOptions {
    * @default false
    */
   lengthMarker?: '#' | false
+
+  /**
+   * Optional flag to flatten nested objects to a single level.
+   * @default false
+   */
+  flatten?: boolean
+
+  /**
+   * Optional maximum depth to flatten nested objects.
+   * @default 3
+   */
+  flattenDepth?: number
 }
 
 export type ResolvedEncodeOptions = Readonly<Required<EncodeOptions>>

--- a/packages/toon/test/flatten.test.ts
+++ b/packages/toon/test/flatten.test.ts
@@ -1,0 +1,53 @@
+import { encode } from '../dist/index.js'
+import { performance } from 'node:perf_hooks'
+
+// --- Utility: Generate deeply nested + wide dataset ---
+function generateBigNestedData(breadth = 8, depth = 5): any {
+  const makeNode = (lvl: number): any => {
+    if (lvl >= depth) {
+      return {
+        id: Math.floor(Math.random() * 10000),
+        name: `User_${lvl}_${Math.random().toString(36).slice(2, 7)}`,
+        age: Math.floor(Math.random() * 60) + 18,
+        active: Math.random() > 0.5,
+        balance: parseFloat((Math.random() * 10000).toFixed(2)),
+      }
+    }
+    const obj: Record<string, any> = {}
+    for (let i = 0; i < breadth; i++) {
+      obj[`level${lvl}_node${i}`] = makeNode(lvl + 1)
+    }
+    return obj
+  }
+  return { root: makeNode(0) }
+}
+
+// --- Generate large data ---
+console.log('Generating large nested JSON...')
+const data = generateBigNestedData(8, 5) // 8 branches × 5 levels deep
+console.log('Data generated. Example keys at root:', Object.keys(data.root).length)
+
+// --- Encode without flatten ---
+console.log('\n--- Encoding WITHOUT flatten ---')
+const t1 = performance.now()
+const encodedRaw = encode(data, { indent: 2, delimiter: ',' })
+const t2 = performance.now()
+console.log('✅ Done. Time:', (t2 - t1).toFixed(2), 'ms')
+
+// --- Encode with flatten ---
+console.log('\n--- Encoding WITH flatten ---')
+const t3 = performance.now()
+const encodedFlat = encode(data, { indent: 2, delimiter: ',', flatten: true })
+const t4 = performance.now()
+console.log('✅ Done. Time:', (t4 - t3).toFixed(2), 'ms')
+
+
+
+console.log('\n===== Results =====')
+console.log('Raw size:      ', encodedRaw.length, 'chars')
+console.log('Flattened size:', encodedFlat.length, 'chars')
+
+console.log('Speed overhead:',
+  (((t4 - t3) - (t2 - t1)) / (t2 - t1) * 100).toFixed(2), '%'
+)
+


### PR DESCRIPTION
Add JSON flattening utility to improve TOON performance on nested data 

PR for [75](https://github.com/toon-format/toon/issues/75), [81](https://github.com/toon-format/spec/issues/4)

## Some benchmark example on randomly generated data:

### Random data 1:
<img width="774" height="172" alt="Screenshot 2025-11-05 at 9 05 43 PM" src="https://github.com/user-attachments/assets/30a005aa-1f87-4e02-9b97-728b24990bdf" />


### Random data 2:
<img width="774" height="186" alt="Screenshot 2025-11-05 at 8 49 32 PM" src="https://github.com/user-attachments/assets/8d7820de-2fbb-4d99-bb4c-fe943e99288d" />

### Random data 3:
<img width="774" height="186" alt="Screenshot 2025-11-05 at 8 49 50 PM" src="https://github.com/user-attachments/assets/1f1d1b5e-34e5-462b-a170-414b0060bd22" />



