### PR TITLE
docs: removed deprecated python-toon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,7 +1166,6 @@ Task: Return only users with role "user" as TOON. Use the same header. Set [N] t
 - **Lua/Neovim:** [toon.nvim](https://github.com/thalesgelinger/toon.nvim)
 - **OCaml:** [ocaml-toon](https://github.com/davesnx/ocaml-toon)
 - **PHP:** [toon-php](https://github.com/HelgeSverre/toon-php)
-- **Python:** [python-toon](https://github.com/xaviviro/python-toon)
 - **R**: [toon](https://github.com/laresbernardo/toon)
 - **Ruby:** [toon-ruby](https://github.com/andrepcg/toon-ruby)
 - **Swift:** [TOONEncoder](https://github.com/mattt/TOONEncoder)


### PR DESCRIPTION
Removed deprecated Python implementation `python-toon`. The official one,  `toon_format`, remains.