### PR TITLE
Add Automatic Delimiter Selection (auto) to TOON Encoder

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -60,7 +60,7 @@ cat data.toon | toon --decode
 | `-o, --output <file>` | Output file path (prints to stdout if omitted) |
 | `-e, --encode` | Force encode mode (overrides auto-detection) |
 | `-d, --decode` | Force decode mode (overrides auto-detection) |
-| `--delimiter <char>` | Array delimiter: `,` (comma), `\t` (tab), `\|` (pipe) |
+| `--delimiter <char>` | Array delimiter: `,` (comma), `\t` (tab), `\|` (pipe), or `auto` |
 | `--indent <number>` | Indentation size (default: `2`) |
 | `--stats` | Show token count estimates and savings (encode only) |
 | `--no-strict` | Disable strict validation when decoding |
@@ -92,6 +92,13 @@ Example output:
 
 ```bash
 toon data.json --delimiter "\t" -o output.toon
+```
+
+#### Auto-select delimiter
+
+```bash
+# Let TOON choose the delimiter that avoids extra quoting
+toon data.json --delimiter auto -o output.toon
 ```
 
 #### Pipe-separated with length markers

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -94,7 +94,7 @@ export const mainCommand: CommandDef<{
     },
     delimiter: {
       type: 'string',
-      description: 'Delimiter for arrays: comma (,), tab (\\t), or pipe (|)',
+      description: 'Delimiter for arrays: comma (,), tab (\\t), pipe (|), or auto',
       default: ',',
     },
     indent: {
@@ -142,10 +142,14 @@ export const mainCommand: CommandDef<{
     }
 
     // Validate delimiter
-    const delimiter = args.delimiter || DEFAULT_DELIMITER
-    if (!(Object.values(DELIMITERS)).includes(delimiter as Delimiter)) {
-      throw new Error(`Invalid delimiter "${delimiter}". Valid delimiters are: comma (,), tab (\\t), pipe (|)`)
+    const delimiterInput = args.delimiter || DEFAULT_DELIMITER
+    const delimiterValues = Object.values(DELIMITERS)
+    if (delimiterInput !== 'auto' && !delimiterValues.includes(delimiterInput as Delimiter)) {
+      throw new Error(`Invalid delimiter "${delimiterInput}". Valid delimiters are: comma (,), tab (\\t), pipe (|), auto`)
     }
+    const delimiterOption = (delimiterInput === 'auto'
+      ? 'auto'
+      : delimiterInput) as NonNullable<EncodeOptions['delimiter']>
 
     // Validate `keyFolding`
     const keyFolding = args.keyFolding || 'off'
@@ -175,7 +179,7 @@ export const mainCommand: CommandDef<{
         await encodeToToon({
           input: inputSource,
           output: outputPath,
-          delimiter: delimiter as Delimiter,
+          delimiter: delimiterOption,
           indent,
           keyFolding: keyFolding as NonNullable<EncodeOptions['keyFolding']>,
           flattenDepth,

--- a/packages/toon/src/index.ts
+++ b/packages/toon/src/index.ts
@@ -85,11 +85,27 @@ export function decode(input: string, options?: DecodeOptions): JsonValue {
 }
 
 function resolveOptions(options?: EncodeOptions): ResolvedEncodeOptions {
+  const indent = options?.indent ?? 2
+  const keyFolding = options?.keyFolding ?? 'off'
+  const flattenDepth = options?.flattenDepth ?? Number.POSITIVE_INFINITY
+  const delimiterOption = options?.delimiter ?? DEFAULT_DELIMITER
+
+  if (delimiterOption === 'auto') {
+    return {
+      indent,
+      delimiter: DEFAULT_DELIMITER,
+      delimiterStrategy: 'auto',
+      keyFolding,
+      flattenDepth,
+    }
+  }
+
   return {
-    indent: options?.indent ?? 2,
-    delimiter: options?.delimiter ?? DEFAULT_DELIMITER,
-    keyFolding: options?.keyFolding ?? 'off',
-    flattenDepth: options?.flattenDepth ?? Number.POSITIVE_INFINITY,
+    indent,
+    delimiter: delimiterOption,
+    delimiterStrategy: 'fixed',
+    keyFolding,
+    flattenDepth,
   }
 }
 

--- a/packages/toon/src/types.ts
+++ b/packages/toon/src/types.ts
@@ -11,6 +11,8 @@ export type JsonValue = JsonPrimitive | JsonObject | JsonArray
 
 // #region Encoder options
 
+export type DelimiterOption = Delimiter | 'auto'
+
 export type { Delimiter, DelimiterKey }
 
 export interface EncodeOptions {
@@ -23,7 +25,7 @@ export interface EncodeOptions {
    * Delimiter to use for tabular array rows and inline primitive arrays.
    * @default DELIMITERS.comma
    */
-  delimiter?: Delimiter
+  delimiter?: DelimiterOption
   /**
    * Enable key folding to collapse single-key wrapper chains.
    * When set to 'safe', nested objects with single keys are collapsed into dotted paths
@@ -40,7 +42,13 @@ export interface EncodeOptions {
   flattenDepth?: number
 }
 
-export type ResolvedEncodeOptions = Readonly<Required<EncodeOptions>>
+export interface ResolvedEncodeOptions {
+  readonly indent: number
+  readonly delimiter: Delimiter
+  readonly delimiterStrategy: 'fixed' | 'auto'
+  readonly keyFolding: 'off' | 'safe'
+  readonly flattenDepth: number
+}
 
 // #endregion
 


### PR DESCRIPTION
This PR introduces a new auto delimiter mode to the TOON encoder.
When enabled, the encoder analyzes the content of arrays and selects the delimiter that produces the least collisions, reducing the need for quoting and improving readability.

What this feature does

Automatically chooses the safest delimiter for:

inline primitive arrays

arrays of arrays (list-item formatting)

tabular arrays (uniform objects)

Scores potential delimiters (tab, pipe, comma) based on how often they appear in the data.

Picks the delimiter with lowest collision count, using this priority:

\t (tab)

| (pipe)

, (comma)

Key changes

CLI updated to accept --delimiter auto.

New option field: delimiterStrategy: 'fixed' | 'auto'.

Added helper functions to:

collect relevant strings

count delimiter collisions

perform automatic selection

Encoder logic updated to use the resolved delimiter per array type.

Unit tests added for the new behavior.

Documentation updated to mention the new flag and behavior.

Why this matters

Avoids unnecessary quoting in TOON output.

Produces cleaner, smaller encoded files.

Handles real-world data gracefully (tags, names, CSV-like strings).

Fully backward-compatible: existing workflows using fixed delimiters are unaffected.