### PR TITLE
fix: remove deprecated NPM config for PNPM-only project (clean)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-shamefully-hoist=true
+


### PR DESCRIPTION
## Description

Clean fix for PNPM configuration issue - removes deprecated NPM setting from `.npmrc` file.

## Problem Solved

The project uses PNPM as the package manager (`"packageManager": "pnpm@10.21.0"`) but contained a deprecated NPM-specific configuration that caused warnings:

```
npm warn Unknown project config "shamefully-hoist". This will stop working in the next major version of npm.
```

## Changes Made

- **Single file change**: Removed `shamefully-hoist=true` from `.npmrc` file
- This setting is NPM-specific and doesn't apply to PNPM
- PNPM handles dependency hoisting through its own mechanisms

## Impact

- Eliminates deprecation warnings during builds
- Aligns configuration with PNPM-only usage
- Zero functional impact (setting was non-functional for PNPM)
- Future-proofs against NPM removing this deprecated option

## Testing

- Verified builds run without warnings
- Confirmed PNPM workspace functionality unchanged
- All existing scripts continue to work properly

## File Changes

- `.npmrc` - 1 line removed (deprecated configuration)

Fixes #170