### PR TITLE
fix: remove deprecated NPM configuration from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-shamefully-hoist=true
+


### PR DESCRIPTION
Closes #170

## Summary

**Type**: Bug Fix  
**Size**: Small (1 line changed, 1 file)  
**API Impact**: None - configuration only

Removes deprecated NPM configuration from `.npmrc` file to eliminate build warnings and align project configuration with PNPM-only usage.

## Problem Solved

The project uses PNPM as the package manager (`"packageManager": "pnpm@10.21.0"`) but contained deprecated NPM-specific configuration causing warnings:

```
npm warn Unknown project config "shamefully-hoist". This will stop working in the next major version of npm.
```

## Root Cause

The `.npmrc` file contained `shamefully-hoist=true` which:
- Is NPM-specific and doesn't apply to PNPM
- Is deprecated and will be removed in future NPM versions
- Provides no functional benefit since project uses PNPM exclusively
- PNPM handles dependency hoisting through its own mechanisms

## Changes Made

**Single file modification**: Removed `shamefully-hoist=true` line from `.npmrc` file

## Impact Assessment

- **Risk Level**: Minimal - removes non-functional configuration only
- **Immediate Benefit**: Eliminates deprecation warnings during builds
- **Compatibility**: Zero impact on PNPM workspace functionality
- **Future-proofing**: Prevents issues when NPM removes deprecated option

## Project Context

- **Package Manager**: PNPM 10.21.0 (defined in package.json)
- **Workspace**: Configured with pnpm-workspace.yaml
- **Scripts**: All build scripts use PNPM commands
- **Hoisting**: PNPM handles this differently than NPM

## Testing Verification

- Confirmed builds run without warnings
- Verified PNPM workspace functionality unchanged
- Validated all existing scripts continue working properly
- No regression in package resolution or installation

## Breaking Changes

None - configuration change only affects warning messages.

## Files Modified

- `.npmrc` - 1 line removed (deprecated configuration)