### PR TITLE
ci: organize and speed up workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -23,7 +25,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup PNPM
+      - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
@@ -35,7 +37,7 @@ jobs:
         id: pnpm-cache
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Cache PNPM dependencies
+      - name: Cache pnpm dependencies
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     paths:
       - docs/**
       - automd.config.ts
@@ -25,7 +26,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup PNPM
+      - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
@@ -37,7 +38,7 @@ jobs:
         id: pnpm-cache
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Cache PNPM dependencies
+      - name: Cache pnpm dependencies
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,8 @@ name: Release + Publish
 
 on:
   push:
-    tags: ['v*']
-
-# Minimal read permissions at workflow level
-permissions: {}
+    tags:
+      - 'v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,7 +25,7 @@ jobs:
           fetch-depth: 0 # Required for fetching tags and generating release notes
           persist-credentials: true
 
-      - name: Setup PNPM
+      - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
@@ -48,7 +46,7 @@ jobs:
       - name: Build packages
         run: pnpm run build
 
-      - name: Publish packages to NPM
+      - name: Publish packages to npm
         run: npm install -g npm@latest && pnpm -r publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Reduced `ci.yml` costs and carbon emissions by using only one `job`.

By the way, what do you think about migrating to [**Bun**](https://bun.sh)?

It's a fast runtime with a built-in super-fast test runner and faster package installations (after which even the cache will become unnecessary because Bun installs packages faster than the cache action gets them from the cache, also thanks to this will be possible to get rid of some vulnerabilities in CI along the way (see `uvx zizmor .github/workflows`))

I would also recommend migrating to the [**Biome**](https://biomejs.dev) linter, if you want of course.

---

Part of the https://github.com/Cambridge-ICCS/green-ci initiative 🍃