### PR TITLE
feat: add replacer option for encode functions

### DIFF
--- a/packages/toon/src/encode/normalize.ts
+++ b/packages/toon/src/encode/normalize.ts
@@ -1,68 +1,165 @@
-import type { JsonArray, JsonObject, JsonPrimitive, JsonValue } from '../types'
+import type { JsonArray, JsonObject, JsonPrimitive, JsonValue, Replacer, ReplacerFunction } from '../types'
+
+// #region Replacer helpers
+
+/**
+ * Symbol used to mark a value as "should be omitted" during normalization.
+ * This is needed because undefined can be a valid return from replacer meaning "omit".
+ */
+const OMIT_VALUE: unique symbol = Symbol('OMIT_VALUE')
+type OmitValue = typeof OMIT_VALUE
+
+/**
+ * Converts a replacer (function or array) into a normalized replacer function.
+ */
+function createReplacerFunction(replacer: Replacer): ReplacerFunction {
+  if (typeof replacer === 'function') {
+    return replacer
+  }
+
+  // Array replacer: create an allowlist set for O(1) lookups
+  const allowedKeys = new Set(replacer.map(String))
+  return (key: string, value: unknown) => {
+    // Always include root value (empty key) and array indices
+    if (key === '' || !Number.isNaN(Number(key))) {
+      return value
+    }
+    return allowedKeys.has(key) ? value : undefined
+  }
+}
+
+// #endregion
 
 // #region Normalization (unknown → JsonValue)
 
-export function normalizeValue(value: unknown): JsonValue {
+/**
+ * Normalizes an unknown value to a JsonValue, optionally applying a replacer function.
+ *
+ * @param value - The value to normalize
+ * @param replacer - Optional replacer function or array (like JSON.stringify)
+ * @returns The normalized JsonValue
+ */
+export function normalizeValue(value: unknown, replacer?: Replacer): JsonValue {
+  const replacerFn = replacer ? createReplacerFunction(replacer) : undefined
+  const result = normalizeWithReplacer('', value, replacerFn)
+  // Root value should never be OMIT_VALUE in normal usage, but handle it gracefully
+  if (result === OMIT_VALUE) {
+    return null
+  }
+  return result
+}
+
+/**
+ * Internal recursive normalization with replacer support.
+ * Returns OMIT_VALUE symbol if the value should be omitted from output.
+ */
+function normalizeWithReplacer(
+  key: string,
+  value: unknown,
+  replacerFn: ReplacerFunction | undefined,
+): JsonValue | OmitValue {
+  // Apply replacer first (like JSON.stringify behavior)
+  let processedValue = value
+  if (replacerFn) {
+    processedValue = replacerFn(key, value)
+    // undefined means "omit this value"
+    if (processedValue === undefined) {
+      return OMIT_VALUE
+    }
+  }
+
   // null
-  if (value === null) {
+  if (processedValue === null) {
     return null
   }
 
   // Primitives
-  if (typeof value === 'string' || typeof value === 'boolean') {
-    return value
+  if (typeof processedValue === 'string' || typeof processedValue === 'boolean') {
+    return processedValue
   }
 
   // Numbers: canonicalize -0 to 0, handle NaN and Infinity
-  if (typeof value === 'number') {
-    if (Object.is(value, -0)) {
+  if (typeof processedValue === 'number') {
+    if (Object.is(processedValue, -0)) {
       return 0
     }
-    if (!Number.isFinite(value)) {
+    if (!Number.isFinite(processedValue)) {
       return null
     }
-    return value
+    return processedValue
   }
 
   // BigInt → number (if safe) or string
-  if (typeof value === 'bigint') {
+  if (typeof processedValue === 'bigint') {
     // Try to convert to number if within safe integer range
-    if (value >= Number.MIN_SAFE_INTEGER && value <= Number.MAX_SAFE_INTEGER) {
-      return Number(value)
+    if (processedValue >= Number.MIN_SAFE_INTEGER && processedValue <= Number.MAX_SAFE_INTEGER) {
+      return Number(processedValue)
     }
     // Otherwise convert to string (will be quoted in output)
-    return value.toString()
+    return processedValue.toString()
   }
 
   // Date → ISO string
-  if (value instanceof Date) {
-    return value.toISOString()
+  if (processedValue instanceof Date) {
+    return processedValue.toISOString()
   }
 
   // Array
-  if (Array.isArray(value)) {
-    return value.map(normalizeValue)
+  if (Array.isArray(processedValue)) {
+    const result: JsonValue[] = []
+    for (let i = 0; i < processedValue.length; i++) {
+      const normalized = normalizeWithReplacer(String(i), processedValue[i], replacerFn)
+      // Arrays always include the value (even if replacer returns undefined, we use null)
+      // This matches JSON.stringify behavior for arrays
+      if (normalized === OMIT_VALUE) {
+        result.push(null)
+      }
+      else {
+        result.push(normalized)
+      }
+    }
+    return result
   }
 
   // Set → array
-  if (value instanceof Set) {
-    return Array.from(value).map(normalizeValue)
+  if (processedValue instanceof Set) {
+    const arr = Array.from(processedValue)
+    const result: JsonValue[] = []
+    for (let i = 0; i < arr.length; i++) {
+      const normalized = normalizeWithReplacer(String(i), arr[i], replacerFn)
+      if (normalized === OMIT_VALUE) {
+        result.push(null)
+      }
+      else {
+        result.push(normalized)
+      }
+    }
+    return result
   }
 
   // Map → object
-  if (value instanceof Map) {
-    return Object.fromEntries(
-      Array.from(value, ([k, v]) => [String(k), normalizeValue(v)]),
-    )
+  if (processedValue instanceof Map) {
+    const normalized: Record<string, JsonValue> = {}
+    for (const [k, v] of processedValue) {
+      const stringKey = String(k)
+      const normalizedValue = normalizeWithReplacer(stringKey, v, replacerFn)
+      if (normalizedValue !== OMIT_VALUE) {
+        normalized[stringKey] = normalizedValue
+      }
+    }
+    return normalized
   }
 
   // Plain object
-  if (isPlainObject(value)) {
+  if (isPlainObject(processedValue)) {
     const normalized: Record<string, JsonValue> = {}
 
-    for (const key in value) {
-      if (Object.prototype.hasOwnProperty.call(value, key)) {
-        normalized[key] = normalizeValue(value[key])
+    for (const objKey in processedValue) {
+      if (Object.prototype.hasOwnProperty.call(processedValue, objKey)) {
+        const normalizedValue = normalizeWithReplacer(objKey, processedValue[objKey], replacerFn)
+        if (normalizedValue !== OMIT_VALUE) {
+          normalized[objKey] = normalizedValue
+        }
       }
     }
 

--- a/packages/toon/src/index.ts
+++ b/packages/toon/src/index.ts
@@ -18,6 +18,8 @@ export type {
   JsonPrimitive,
   JsonStreamEvent,
   JsonValue,
+  Replacer,
+  ReplacerFunction,
   ResolvedDecodeOptions,
   ResolvedEncodeOptions,
 } from './types'
@@ -95,7 +97,7 @@ export function decode(input: string, options?: DecodeOptions): JsonValue {
  * ```
  */
 export function encodeLines(input: unknown, options?: EncodeOptions): Iterable<string> {
-  const normalizedValue = normalizeValue(input)
+  const normalizedValue = normalizeValue(input, options?.replacer)
   const resolvedOptions = resolveOptions(options)
   return encodeJsonValue(normalizedValue, resolvedOptions, 0)
 }
@@ -210,6 +212,7 @@ function resolveOptions(options?: EncodeOptions): ResolvedEncodeOptions {
     delimiter: options?.delimiter ?? DEFAULT_DELIMITER,
     keyFolding: options?.keyFolding ?? 'off',
     flattenDepth: options?.flattenDepth ?? Number.POSITIVE_INFINITY,
+    replacer: options?.replacer,
   }
 }
 

--- a/packages/toon/src/types.ts
+++ b/packages/toon/src/types.ts
@@ -9,6 +9,42 @@ export type JsonValue = JsonPrimitive | JsonObject | JsonArray
 
 // #endregion
 
+// #region Replacer types
+
+/**
+ * A function that transforms values during encoding, similar to JSON.stringify's replacer.
+ *
+ * @param key - The property key (empty string for root value)
+ * @param value - The value to transform
+ * @returns The transformed value, or undefined to omit the property
+ *
+ * @example
+ * ```ts
+ * // Omit sensitive fields
+ * const replacer: ReplacerFunction = (key, value) => {
+ *   if (key === 'password') return undefined
+ *   return value
+ * }
+ *
+ * // Transform values
+ * const replacer: ReplacerFunction = (key, value) => {
+ *   if (typeof value === 'string') return value.toUpperCase()
+ *   return value
+ * }
+ * ```
+ */
+export type ReplacerFunction = (key: string, value: unknown) => unknown
+
+/**
+ * Replacer for encoding - either a function or an array of allowed keys.
+ *
+ * - Function: Called for each value, return undefined to omit
+ * - Array: Allowlist of property names to include (only applies to objects)
+ */
+export type Replacer = ReplacerFunction | (string | number)[]
+
+// #endregion
+
 // #region Encoder options
 
 export type { Delimiter, DelimiterKey }
@@ -38,9 +74,32 @@ export interface EncodeOptions {
    * @default Infinity
    */
   flattenDepth?: number
+  /**
+   * A function or array that transforms values during encoding,
+   * similar to JSON.stringify's replacer parameter.
+   *
+   * - Function: Called for each value with (key, value). Return undefined to omit the property.
+   * - Array: Allowlist of property names to include (only applies to objects).
+   *
+   * @default undefined
+   *
+   * @example
+   * ```ts
+   * // Omit sensitive fields
+   * encode(user, {
+   *   replacer: (key, value) => key === 'password' ? undefined : value
+   * })
+   *
+   * // Include only specific fields
+   * encode(user, {
+   *   replacer: ['id', 'name', 'email']
+   * })
+   * ```
+   */
+  replacer?: Replacer
 }
 
-export type ResolvedEncodeOptions = Readonly<Required<EncodeOptions>>
+export type ResolvedEncodeOptions = Readonly<Required<Omit<EncodeOptions, 'replacer'>> & Pick<EncodeOptions, 'replacer'>>
 
 // #endregion
 

--- a/packages/toon/test/replacer.test.ts
+++ b/packages/toon/test/replacer.test.ts
@@ -1,0 +1,262 @@
+/* eslint-disable test/prefer-lowercase-title */
+import { describe, expect, it } from 'vitest'
+import { encode } from '../src/index'
+
+describe('Replacer option', () => {
+  describe('Function replacer', () => {
+    it('omits properties when returning undefined', () => {
+      const user = { id: 1, password: 'hunter2', name: 'Alice' }
+      const result = encode(user, {
+        replacer: (key, value) => {
+          if (key === 'password') return undefined
+          return value
+        },
+      })
+      expect(result).toBe('id: 1\nname: Alice')
+    })
+
+    it('transforms values', () => {
+      const data = { name: 'alice', city: 'boston' }
+      const result = encode(data, {
+        replacer: (key, value) => {
+          if (typeof value === 'string' && key !== '') {
+            return value.toUpperCase()
+          }
+          return value
+        },
+      })
+      expect(result).toBe('name: ALICE\ncity: BOSTON')
+    })
+
+    it('receives empty string key for root value', () => {
+      const keys: string[] = []
+      encode({ a: 1, b: 2 }, {
+        replacer: (key, value) => {
+          keys.push(key)
+          return value
+        },
+      })
+      expect(keys[0]).toBe('')
+    })
+
+    it('works with nested objects', () => {
+      const data = {
+        user: {
+          id: 1,
+          secret: 'hidden',
+          profile: {
+            name: 'Alice',
+            token: 'abc123',
+          },
+        },
+      }
+      const result = encode(data, {
+        replacer: (key, value) => {
+          if (key === 'secret' || key === 'token') return undefined
+          return value
+        },
+      })
+      expect(result).toBe('user:\n  id: 1\n  profile:\n    name: Alice')
+    })
+
+    it('works with arrays - omitted values become null', () => {
+      const data = [1, 2, 3, 4, 5]
+      const result = encode(data, {
+        replacer: (key, value) => {
+          // Omit values > 3 in arrays
+          if (key !== '' && typeof value === 'number' && value > 3) {
+            return undefined
+          }
+          return value
+        },
+      })
+      // Arrays preserve indices, so omitted values become null
+      expect(result).toBe('[5]: 1,2,3,null,null')
+    })
+
+    it('can replace entire root object', () => {
+      const data = { original: true }
+      const result = encode(data, {
+        replacer: (key, value) => {
+          if (key === '') return { replaced: true }
+          return value
+        },
+      })
+      expect(result).toBe('replaced: true')
+    })
+
+    it('omitting root returns empty output', () => {
+      const data = { a: 1 }
+      const result = encode(data, {
+        replacer: (key) => {
+          if (key === '') return undefined
+          return undefined
+        },
+      })
+      // When root is omitted, we get null (converted to empty by encode)
+      expect(result).toBe('null')
+    })
+
+    it('works with tabular arrays', () => {
+      const users = [
+        { id: 1, name: 'Alice', password: 'secret1' },
+        { id: 2, name: 'Bob', password: 'secret2' },
+      ]
+      const result = encode(users, {
+        replacer: (key, value) => {
+          if (key === 'password') return undefined
+          return value
+        },
+      })
+      expect(result).toBe('[2]{id,name}:\n  1,Alice\n  2,Bob')
+    })
+  })
+
+  describe('Array replacer (allowlist)', () => {
+    it('includes only allowed keys', () => {
+      const user = { id: 1, name: 'Alice', email: 'alice@example.com', password: 'secret' }
+      const result = encode(user, {
+        replacer: ['id', 'name'],
+      })
+      expect(result).toBe('id: 1\nname: Alice')
+    })
+
+    it('works with nested objects', () => {
+      const data = {
+        user: {
+          id: 1,
+          name: 'Alice',
+          secret: 'hidden',
+        },
+        meta: {
+          created: '2025-01-01',
+          internal: 'private',
+        },
+      }
+      const result = encode(data, {
+        replacer: ['user', 'meta', 'id', 'name', 'created'],
+      })
+      expect(result).toBe('user:\n  id: 1\n  name: Alice\nmeta:\n  created: 2025-01-01')
+    })
+
+    it('always includes array indices', () => {
+      const data = { items: ['a', 'b', 'c'] }
+      const result = encode(data, {
+        replacer: ['items'],
+      })
+      expect(result).toBe('items[3]: a,b,c')
+    })
+
+    it('handles numeric keys in allowlist', () => {
+      const data = { id: 1, name: 'Alice' }
+      const result = encode(data, {
+        replacer: ['id', 1], // 1 is converted to string '1'
+      })
+      expect(result).toBe('id: 1')
+    })
+
+    it('empty allowlist omits all object keys', () => {
+      const data = { a: 1, b: 2, c: 3 }
+      const result = encode(data, {
+        replacer: [],
+      })
+      expect(result).toBe('')
+    })
+
+    it('works with tabular arrays and allowlist', () => {
+      const users = [
+        { id: 1, name: 'Alice', email: 'a@x.com', role: 'admin' },
+        { id: 2, name: 'Bob', email: 'b@x.com', role: 'user' },
+      ]
+      const result = encode(users, {
+        replacer: ['id', 'name'],
+      })
+      expect(result).toBe('[2]{id,name}:\n  1,Alice\n  2,Bob')
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('works with primitives at root', () => {
+      const result = encode('hello', {
+        replacer: (key, value) => {
+          if (typeof value === 'string') return value.toUpperCase()
+          return value
+        },
+      })
+      expect(result).toBe('HELLO')
+    })
+
+    it('works with null at root', () => {
+      const result = encode(null, {
+        replacer: (key, value) => value,
+      })
+      expect(result).toBe('null')
+    })
+
+    it('works with empty object', () => {
+      const result = encode({}, {
+        replacer: ['id'],
+      })
+      expect(result).toBe('')
+    })
+
+    it('works with empty array', () => {
+      const result = encode([], {
+        replacer: (key, value) => value,
+      })
+      expect(result).toBe('[0]:')
+    })
+
+    it('replacer can convert types', () => {
+      const data = { date: new Date('2025-01-01T00:00:00.000Z') }
+      const result = encode(data, {
+        replacer: (key, value) => {
+          if (value instanceof Date) {
+            return value.getFullYear()
+          }
+          return value
+        },
+      })
+      expect(result).toBe('date: 2025')
+    })
+
+    it('works with deeply nested structures', () => {
+      const data = {
+        level1: {
+          level2: {
+            level3: {
+              secret: 'hidden',
+              visible: 'shown',
+            },
+          },
+        },
+      }
+      const result = encode(data, {
+        replacer: (key, value) => {
+          if (key === 'secret') return undefined
+          return value
+        },
+      })
+      expect(result).toBe('level1:\n  level2:\n    level3:\n      visible: shown')
+    })
+
+    it('combines with other options like keyFolding', () => {
+      const data = {
+        wrapper: {
+          inner: {
+            id: 1,
+            secret: 'hidden',
+          },
+        },
+      }
+      const result = encode(data, {
+        keyFolding: 'safe',
+        replacer: (key, value) => {
+          if (key === 'secret') return undefined
+          return value
+        },
+      })
+      expect(result).toBe('wrapper.inner.id: 1')
+    })
+  })
+})


### PR DESCRIPTION
Implements a replacer option that works like JSON.stringify's replacer parameter, allowing users to filter or transform values during encoding.

- Add ReplacerFunction and Replacer types
- Support function replacer (filter/transform values)
- Support array replacer (allowlist of keys)
- Add 21 comprehensive tests
- Document replacer in API reference

Closes #209