### PR TITLE
docs(readme): add TOONDecoder Swift library reference

### DIFF
--- a/packages/toon/README.md
+++ b/packages/toon/README.md
@@ -915,7 +915,7 @@ Comprehensive guides, references, and resources to help you get the most out of 
 - **Laravel Framework:** [laravel-toon](https://github.com/jobmetric/laravel-toon)
 - **R**: [toon](https://github.com/laresbernardo/toon)
 - **Ruby:** [toon-ruby](https://github.com/andrepcg/toon-ruby)
-- **Swift:** [TOONEncoder](https://github.com/mattt/TOONEncoder)
+- **Swift:** [TOONEncoder](https://github.com/mattt/TOONEncoder)/[TOONDecoder](https://github.com/alexey1312/TOONDecoder)
 - **Kotlin:** [Kotlin-Toon Encoder/Decoder](https://github.com/vexpera-br/kotlin-toon)
 
 ## Credits


### PR DESCRIPTION
This pull request updates the Swift section of the resource list in the `packages/toon/README.md` file to include both the encoder and decoder libraries for Swift. This helps users find comprehensive Swift support for TOON encoding and decoding.

Resource documentation update:

* Added a reference to `TOONDecoder` alongside `TOONEncoder` in the Swift section to provide links to both encoding and decoding libraries for Swift.