### PR TITLE
docs(benchmarks): add generation benchmarks

### DIFF
--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -1,6 +1,7 @@
 # Benchmarks
 
-The benchmarks on this page measure TOON's performance across two key dimensions:
+## 1. Comprehension Benchmarks
+The benchmarks in this section measure TOON's performance across two key dimensions:
 
 - **Retrieval Accuracy**: How well LLMs understand and extract information from different input formats.
 - **Token Efficiency**: How many tokens each format requires to represent the same data.
@@ -575,6 +576,105 @@ repositories[3]{id,name,repo,description,createdAt,updatedAt,pushedAt,stars,watc
 </details>
 
 <!-- /automd -->
+
+## 2. Generation Benchmarks
+
+We also evaluate formats as model output targets for structured data generation. While TOON is primarily designed for input, its token efficiency makes it a candidate for LLM output in specific high-volume scenarios. 
+
+[Token-Oriented Object Notation vs JSON: a benchmark of plain and constrained decoding generation](https://github.com/vetertann/TOON-generation-benchmark) is a structured generation benchmark comparing plain JSON, JSON with constrained decoding (structured output), and TOON in-context learning across 21 models and 4 test cases of increasing complexity (flat tabular, nested uniform,  deep hierarchies), measuring accuracy, token efficiency, and repair costs.
+
+
+### Benchmark design
+
+**Gold standard:** Created from Pydantic models and serialized to `*.gold.json` (canonical JSON) and `*.gold.toon` (via `@toon-format/cli`).
+
+**Test cases:**
+1.  **users**: Simple tabular structure.
+2.  **order**: Nested structure with array.
+3.  **company**: Department and employee hierarchy (deep nesting).
+4.  **invoice**: Items and totals.
+
+**Test tracks:**
+*   **JSON track (J):** Plain JSON generation with Pydantic validation.
+*   **JSON-SO track (JSO):** Structured output (`response_format="json_object"`) with constrained decoding. The inference engine compiles constraints (schema/grammar) into a state machine (e.g., xgrammar) to mask illegal tokens during generation, enforcing valid syntax.
+*   **TOON track (T):** TOON output followed by CLI decoding. Prompts used **universal examples** (not custom-tailored to the specific schema) to ensure a fair comparison with JSON.
+
+**Sampling & evaluation:**
+*   **Parameters:** Temperature 0 for deterministic output.
+*   **Runs:** 10 iterations per test case per model (21 models via [Nebius API](https://tokenfactory.nebius.com/)).
+*   **Process:**
+    1.  Model generates output (J, JSO, or T).
+    2.  (TOON only) CLI decodes to JSON. CLI errors trigger a **repair cycle**.
+    3.  Validation via Pydantic & Data canonicalization.
+    4.  Comparison with Gold Standard.
+    5.  **Repair cycle:** If validation/comparison fails, the previous output and error text are inserted into the prompt (up to 3 attempts).
+
+### Key findings
+
+*   **Aligned data ("sweet spot"):** TOON excels in tabular and uniform nested structures (e.g., invoices, orders), achieving **90.5%** accuracy in 1-shot tests while offering significant token savings.
+*   **Prompt tax:** Unlike JSON, which is native to model training, TOON requires instructional prompting. For short outputs, this overhead reduces efficiency; for larger outputs (batches/logs), the syntax savings amortize the cost.
+*   **Structured output trade-off:** Constrained decoding (CD) acts as a safety net for smaller models (preventing syntax errors) but was found to degrade reasoning/accuracy in some larger models ("structured output paradox"). This result hints that TOON enforcing via CD may not yield the desired results.
+
+### Results by data topology
+
+Performance varies significantly based on how well the data aligns with TOON's design (e.g., uniform arrays vs. deep recursive nesting).
+
+| Case | J (1-S) | J (Fin) | J (Tok) | JSO (1-S) | JSO (Fin) | JSO (Tok) | T (1-S) | T (Fin) | T (Tok) |
+| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| **users** | 94.8% | 94.8% | 1078 | 92.9% | **100%** | 556 | **90.5%** | 90.5% | 840 |
+| **order** | 81.9% | 81.9% | 1746 | 78.6% | 83.3% | 1255 | 74.3% | 78.6% | 1585 |
+| **company** | 18.6% | 43.8% | 3575 | **21.9%** | **48.1%** | 2592 | 0.0% | 48.6% | 2567 |
+| **invoice** | 90.0% | 90.0% | 1723 | 87.6% | **95.2%** | 1349 | 0.0% | 52.4% | 3626 |
+
+### Full results by model
+
+The following table compares **1-shot accuracy (1-S)**, **final accuracy (Fin)** after repair loops, and the total **token budget (Tok)** required for successful generation.
+
+| Model | J (1-S) | J (Fin) | J (Tok) | JSO (1-S) | JSO (Fin) | JSO (Tok) | T (1-S) | T (Fin) | T (Tok) |
+| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| **NousResearch/Hermes-4-405B** | 92.5% | 92.5% | 3252 | 35.0% | **100%** | 4759 | 50.0% | 60.0% | 4671 |
+| **NousResearch/Hermes-4-70B** | 75.0% | 75.0% | 4414 | 37.5% | 75.0% | 5594 | 50.0% | 50.0% | 4738 |
+| **PrimeIntellect/INTELLECT-3** | 72.5% | 75.0% | 10682 | 72.5% | 77.5% | 10103 | 40.0% | 65.0% | 13315 |
+| **Qwen/Qwen2.5-Coder-7B-fast** | 0.0% | 0.0% | 37705 | 75.0% | 75.0% | 4440 | 27.5% | 27.5% | 32715 |
+| **Qwen/Qwen3-235B-A22B-Inst** | **100%** | **100%** | 2772 | **100%** | **100%** | 2772 | 50.0% | **100%** | 4715 |
+| **Qwen/Qwen3-235B-A22B-Thk** | 82.5% | 82.5% | 11425 | 87.5% | 97.5% | 7899 | 50.0% | 97.5% | 17457 |
+| **Qwen/Qwen3-30B-A3B-Inst** | 75.0% | 75.0% | 4436 | 75.0% | 75.0% | 4436 | 50.0% | 70.0% | 5505 |
+| **Qwen/Qwen3-32B** | 75.0% | 77.5% | 10196 | 75.0% | 75.0% | 4120 | 47.5% | 80.0% | 9101 |
+| **Qwen/Qwen3-Coder-30B-A3B** | 75.0% | 75.0% | 4206 | 75.0% | 75.0% | 4206 | 50.0% | **100%** | 4719 |
+| **Qwen/Qwen3-Coder-480B** | 75.0% | 75.0% | 4462 | 75.0% | 75.0% | 4447 | 50.0% | 75.0% | 4515 |
+| **deepseek-ai/DeepSeek-R1** | 55.0% | 70.0% | 13811 | 65.0% | 80.0% | 4149 | 25.0% | 50.0% | 19047 |
+| **deepseek-ai/DeepSeek-V3-fast** | 75.0% | **100%** | 3600 | 75.0% | **100%** | 3584 | 25.0% | 80.0% | 4734 |
+| **google/gemma-2-2b-it** | 75.0% | **100%** | 4721 | 77.5% | **100\%** | 4566 | 0.0% | 0.0% | 5955 |
+| **google/gemma-2-9b-it-fast** | 75.0% | 75.0% | 6086 | 75.0% | 75.0% | 6056 | 50.0% | 75.0% | 5419 |
+| **meta-llama/Llama-3.3-70B** | 75.0% | 75.0% | 4551 | 75.0% | 75.0% | 4447 | 50.0% | 50.0% | 5148 |
+| **meta-llama/Llama-3.1-8B** | 72.5% | 72.5% | 7235 | 75.0% | 75.0% | 6941 | 22.5\% | 25.0% | 4915 |
+| **moonshotai/Kimi-K2-Instruct** | 50.0% | 75.0% | 4284 | 50.0% | 75.0% | 4283 | 50.0\% | **100\%** | 3937 |
+| **nvidia/Llama-3_1-Nemotron** | 75.0% | 75.0% | 4426 | 50.0% | 50.0% | 5714 | 50.0% | 82.5% | 4368 |
+| **openai/gpt-oss-120b** | **97.5%** | **100%** | 3685 | **100%** | **100%** | 3545 | 50.0% | 87.5% | 8223 |
+| **openai/gpt-oss-20b** | 50.0% | 72.5% | 14943 | 50.0% | 67.5% | 15601 | 50.0% | 90.0% | 9678 |
+| **zai-org/GLM-4.5** | 75.0% | 87.5% | 9677 | 75.0\% | 92.5\% | 9135 | 27.5\% | 52.5\% | 8110 |
+
+### Observations
+
+**1. The "Structured Output Paradox"**
+Constrained decoding is not always superior. For `Hermes-4-405B`, applying constraints dropped 1-shot accuracy from **92.5%** (Plain JSON) to **35.0%** (Structured Output). This suggests that for some high-reasoning models, forcing specific grammar paths can actively interfere with the model's logic capabilities.  This result also hints that TOON enforcing via frameworks such as xgrammar may not yield the desired results.
+
+**2. Guardrails for smaller models**
+Conversely, for smaller models like `Qwen/Qwen2.5-Coder-7B-fast`, structured output is essential. It raised performance from a catastrophic **0%** (Plain JSON) to a viable **75%**.
+
+**3. TOON repair potential**
+While TOON often has lower initial 1-shot accuracy due to the novelty of the format, several models (`Qwen/Qwen3-Coder-30B`, `Kimi-K2-Instruct`, `Qwen/Qwen3-235B`) achieved **100% final accuracy** after repair loops. This indicates that while the format may be unfamiliar initially, the error messages provided by the TOON CLI are highly effective for self-correction.
+
+**4. Token efficiency scaling**
+In cases like `Qwen3-235B-A22B-Inst`, TOON consumed significantly more tokens (~4700) than JSON (~2700). This confirms the "prompt tax" hypothesis: for short tasks, the instructional overhead outweighs the syntax savings. TOON becomes efficient primarily in high-volume generation where the output length justifies the system prompt.
+
+### Analysis & recommendations
+
+1.  **Aligned data streams:** Use TOON generation for data structures like **SQL dumps, logs, and transactional documents**. The token savings on high-volume, uniform data outweigh the prompt overhead.
+2.  **Avoid deep nesting:** For deeply nested or recursive state trees stick to **JSON** or **JSO**. TOON's indentation tracking is less robust for these structures in one-shot generation.
+3.  **Repair loops:** TOON generation benefits disproportionately from repair loops (feeding errors back to context), often correcting format issues that initial constrained decoding cannot fix.
+4.  **Validate scaling and drift:** Current benchmarks cover small-scale structures (< 50 items). Test larger datasets (100+ items, 10K+ output tokens) to determine where TOON's syntax savings offset prompt overhead and assess susceptibility to indentation drift in long-context generation—whitespace-based formats may accumulate errors over extended outputs.
+
 
 ## Related Resources
 


### PR DESCRIPTION
## Linked Issue

Closes #207

## Description

This PR adds Generation Benchmarks  section to the documentation. It details the performance of TOON compared to JSON and JSON Structured Output (JSO) across 21 different LLMs, focusing on token efficiency, accuracy, and repair capabilities.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- Added `## 2. Generation benchmarks` section to `docs/guide/benchmarks.md`.
- Documented methodology
- Added performance tables comparing 1-shot accuracy, final accuracy (after repair loops), and token budgets across 21 models .
- Included qualitative analysis on the accuracy, repair loops, and token efficiency scaling.

## SPEC Compliance

- [ ] This PR implements/fixes spec compliance
- [x] Spec section(s) affected: N/A (Documentation only)
- [ ] Spec version: N/A

## Testing

- [x] All existing tests pass
- [ ] Added new tests for changes
- [ ] Tests cover edge cases and spec compliance


## Pre-submission Checklist

- [x] My code follows the project's coding standards
- [x] I have run code formatting/linting tools (Markdown linting)
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
- [x] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe migration path below)

## Additional Context

Benchmarks were run via the Nebius API.
