### PR TITLE
fix: quote ambiguous numeric strings starting with . or + (fixes #249)

### DIFF
--- a/packages/toon/src/shared/validation.ts
+++ b/packages/toon/src/shared/validation.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_DELIMITER, LIST_ITEM_MARKER } from '../constants'
 import { isBooleanOrNullLiteral } from './literal-utils'
 
-const NUMERIC_LIKE_PATTERN = /^-?\d+(?:\.\d+)?(?:e[+-]?\d+)?$/i
+const NUMERIC_LIKE_PATTERN = /^[+-]?(\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i
 const LEADING_ZERO_PATTERN = /^0\d+$/
 
 /**

--- a/packages/toon/test/issue-249.test.ts
+++ b/packages/toon/test/issue-249.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { decode, encode } from '../src/index'
+
+describe('Issue 249', () => {
+  it('should preserve strings starting with dot or plus followed by numbers', () => {
+    const indent: number = 1;
+
+    function encodeToon(data: any): string {
+      return encode(data, { indent });
+    }
+
+    function decodeToon<T>(toon: string): T {
+      return decode(toon, { indent }) as any;
+    }
+
+    const data = [
+      '.6226633103089010',
+      '+8613334445577',
+    ]
+
+    // Expecting that it properly encodes these strings so that they decode back to strings
+    // If it encodes them as raw numbers in TOON format without quotes, they might be read back as numbers.
+    const encoded = encodeToon(data);
+    console.log('Encoded:', encoded);
+
+    // Encoded values MUST be quoted to avoid ambiguity with numbers
+    // This assertion will fail initially
+    expect(encoded).toContain('".6226633103089010"');
+    expect(encoded).toContain('"+8613334445577"');
+
+    const decoded = decodeToon(encoded);
+
+    expect(decoded).toEqual(data);
+  })
+})


### PR DESCRIPTION
## Linked Issue

Closes #249

## Description

Fixed a bug where strings starting with `.` or `+` followed by numbers (e.g., `".622"`, `"+861"`) were incorrectly identified as safe to encode without quotes. This caused them to be encoded as raw numeric-like tokens (e.g., `.622`, `+861`), which could be misinterpreted as numbers during decoding in some environments or by other parsers.

The fix expands the numeric detection pattern to ensure these ambiguous strings are explicitly quoted in the output.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- Updated `NUMERIC_LIKE_PATTERN` regex in [packages/toon/src/shared/validation.ts](cci:7://file:///c:/Users/Asus/Desktop/toon/toon/packages/toon/src/shared/validation.ts:0:0-0:0) to include patterns starting with `.` (optional digits before) and explicit `+` signs.
- Added a regression test [packages/toon/test/issue-249.test.ts](cci:7://file:///c:/Users/Asus/Desktop/toon/toon/packages/toon/test/issue-249.test.ts:0:0-0:0) to verify that string values like `".622..."` and `"+861..."` are now properly quoted.

## SPEC Compliance

- [x] This PR implements/fixes spec compliance
- [ ] Spec section(s) affected:
- [ ] Spec version:

## Testing

- [x] All existing tests pass
- [x] Added new tests for changes
- [x] Tests cover edge cases and spec compliance

Verified the fix with the new regression test:
```typescript
const data = ['.6226633103089010', '+8613334445577']
// Encoded output is now: [".6226633103089010", "+8613334445577"]
// Previously was: [.6226633103089010, +8613334445577]