### PR TITLE
ci: use slim Ubuntu runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ permissions: {}
 jobs:
   deploy:
     name: Deploy Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   lint-pr-title:
     name: Lint PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     if: ${{ (github.event.action == 'opened' || github.event.changes.title != null) && github.actor != 'renovate[bot]' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     permissions:
       id-token: write


### PR DESCRIPTION
It will be more environmentally friendly and cheaper (at least for GitHub, because it's a public project and GitHub pays for it, not you)

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- Replaced `ubuntu-latest` with `ubuntu-slim` in all workflows

## Pre-submission Checklist

<!-- Verify before submitting -->

- [x] My code follows the project's coding standards
- [x] I have run code formatting/linting tools
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
- [x] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Breaking Changes

<!-- If this is a breaking change, describe the migration path for users -->

- [x] No breaking changes
- [ ] Breaking changes (describe migration path below)

<!-- Migration path: -->

## Additional Context

GitHub blog post about new 1 vCPU runners: https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview

Pricing (tl;dr: $0.002/min): https://docs.github.com/en/billing/reference/actions-runner-pricing

GitHub-hosted runners reference: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#standard-github-hosted-runners-for--private-repositories
