### PR TITLE
fix: handle objects with null-prototype chains in isPlainObject

### DIFF
--- a/packages/toon/src/encode/normalize.ts
+++ b/packages/toon/src/encode/normalize.ts
@@ -117,8 +117,15 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
     return false
   }
 
-  const prototype = Object.getPrototypeOf(value)
-  return prototype === null || prototype === Object.prototype
+  // Walk up the prototype chain - accept if it ends at null or Object.prototype
+  let prototype = Object.getPrototypeOf(value)
+  while (prototype !== null) {
+    if (prototype === Object.prototype) {
+      return true
+    }
+    prototype = Object.getPrototypeOf(prototype)
+  }
+  return true
 }
 
 // #endregion

--- a/packages/toon/test/encode.test.ts
+++ b/packages/toon/test/encode.test.ts
@@ -51,3 +51,38 @@ function resolveEncodeOptions(options?: TestCase['options']): ResolvedEncodeOpti
     flattenDepth: options?.flattenDepth ?? Number.POSITIVE_INFINITY,
   }
 }
+
+describe('null-prototype objects', () => {
+  it('encodes Object.create(null) as a regular object', () => {
+    const obj = Object.create(null)
+    obj.a = true
+    obj.b = 'hello'
+    expect(encode(obj)).toBe('a: true\nb: hello')
+  })
+
+  it('encodes nested Object.create(null)', () => {
+    const inner = Object.create(null)
+    inner.x = 1
+    const outer = Object.create(null)
+    outer.nested = inner
+    expect(encode(outer)).toBe('nested:\n  x: 1')
+  })
+
+  it('encodes array of Object.create(null) as tabular', () => {
+    const a = Object.create(null)
+    a.id = 1
+    a.name = 'Alice'
+    const b = Object.create(null)
+    b.id = 2
+    b.name = 'Bob'
+    expect(encode([a, b])).toBe('[2]{id,name}:\n  1,Alice\n  2,Bob')
+  })
+
+  it('encodes object with null-prototype as its prototype (only own properties)', () => {
+    const proto = Object.create(null)
+    proto.inherited = 'should not appear'
+    const obj = Object.create(proto)
+    obj.own = 'visible'
+    expect(encode(obj)).toBe('own: visible')
+  })
+})


### PR DESCRIPTION
Objects created with `Object.create(Object.create(null))` were not recognized as plain objects because their prototype is neither `null` nor `Object.prototype`. The fix walks up the prototype chain to check if it terminates at `null` or `Object.prototype`.

## Linked Issue

<!-- Reference the related issue. Example: Closes #123 -->

Closes #

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

<!-- List the main changes in this PR -->

-
-
-

## SPEC Compliance

<!-- If this PR relates to the TOON spec, indicate which sections are affected -->

- [ ] This PR implements/fixes spec compliance
- [ ] Spec section(s) affected:
- [ ] Spec version:

## Testing

<!-- Describe the tests you added or ran -->

- [ ] All existing tests pass
- [ ] Added new tests for changes
- [ ] Tests cover edge cases and spec compliance

## Pre-submission Checklist

<!-- Verify before submitting -->

- [ ] My code follows the project's coding standards
- [ ] I have run code formatting/linting tools
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
- [ ] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Breaking Changes

<!-- If this is a breaking change, describe the migration path for users -->

- [ ] No breaking changes
- [ ] Breaking changes (describe migration path below)

<!-- Migration path: -->

## Additional Context

<!-- Add any other context about the PR here (optional) -->
