### PR TITLE
docs: add `json-io` to community implementations

### DIFF
--- a/docs/ecosystem/implementations.md
+++ b/docs/ecosystem/implementations.md
@@ -38,6 +38,7 @@ Community members have created implementations in additional languages:
 | **Elixir** | [toon_ex](https://github.com/kentaro/toon_ex) | [@kentaro](https://github.com/kentaro) |
 | **Gleam** | [toon_codec](https://github.com/axelbellec/toon_codec) | [@axelbellec](https://github.com/axelbellec) |
 | **Go** | [gotoon](https://github.com/alpkeskin/gotoon) | [@alpkeskin](https://github.com/alpkeskin) |
+| **Java** | [json-io](https://github.com/jdereg/json-io) | [@jdereg](https://github.com/jdereg) |
 | **Kotlin** | [ktoon](https://github.com/lukelast/ktoon)| [@lukelast](https://github.com/lukelast) |
 | **Laravel Framework** | [laravel-toon](https://github.com/mischasigtermans/laravel-toon) | [@mischasigtermans](https://github.com/mischasigtermans) |
 | **Lua/Neovim** | [toon.nvim](https://github.com/thalesgelinger/toon.nvim) | [@thalesgelinger](https://github.com/thalesgelinger) |


### PR DESCRIPTION
## Summary
Adds json-io to the Community Implementations table for Java.

json-io is a comprehensive Java library for TOON serialization that offers:
- **60+ built-in types** (vs ~15 in other Java implementations)
- **Any serializable type as Map keys** (not just strings)
- **EnumSet support**
- **Cyclic reference handling** via `@id`/`@ref`
- **Zero external dependencies** (except java-util)
- Production-ready and stable

Repository: https://github.com/jdereg/json-io

## Changes
- Added json-io entry to Community Implementations table (alphabetically ordered)