### PR TITLE
docs: add Tooner MCP proxy to Tools & Integration section

### DIFF
--- a/docs/ecosystem/tools-and-playgrounds.md
+++ b/docs/ecosystem/tools-and-playgrounds.md
@@ -74,3 +74,9 @@ const data = decode(toon)
 ```
 
 See the [API Reference](/reference/api) for details.
+
+## MCP
+
+### Tooner
+
+[Tooner](https://github.com/chaindead/tooner) – MCP proxy that converts JSON tool responses to TOON.

--- a/packages/toon/README.md
+++ b/packages/toon/README.md
@@ -898,8 +898,9 @@ Comprehensive guides, references, and resources to help you get the most out of 
 ### Tools & Integration
 
 - [CLI](https://toonformat.dev/cli/) – Command-line tool for JSON↔TOON conversions
-- [Using TOON with LLMs](https://toonformat.dev/guide/llm-prompts) – Prompting strategies & validation
 - [Playgrounds](https://toonformat.dev/ecosystem/tools-and-playgrounds) – Interactive tools
+- [Tooner](https://github.com/chaindead/tooner) – MCP proxy that converts JSON tool responses to TOON
+- [Using TOON with LLMs](https://toonformat.dev/guide/llm-prompts) – Prompting strategies & validation
 
 ### References
 


### PR DESCRIPTION
## Description

Add [Tooner](https://github.com/chaindead/tooner) to the "Tools & Integration" section of the README. Tooner is an MCP proxy that wraps MCP servers and auto-converts JSON tool responses to TOON format, saving ~30% tokens on sessions with high mcp-activity.

## Type of Change

- Documentation update

## Changes Made

- Added Tooner link and description to the "Tools & Integration" section in README.md

## Breaking Changes

- No breaking changes