### PR TITLE
Add header-only C++ TOON implementation reference.

### DIFF
--- a/docs/ecosystem/implementations.md
+++ b/docs/ecosystem/implementations.md
@@ -32,6 +32,7 @@ Community members have created implementations in additional languages:
 | **Apex** | [ApexToon](https://github.com/Eacaw/ApexToon) | [@Eacaw](https://github.com/Eacaw) |
 | **C** | [TOONc](https://github.com/UsboKirishima/TOONc) | [@UsboKirishima](https://github.com/UsboKirishima) |
 | **C++** | [ctoon](https://github.com/mohammadraziei/ctoon) | [@mohammadraziei](https://github.com/mohammadraziei) |
+| **C++** | [toon.hpp](https://github.com/xZepyx/toon.hpp) | [@xZepyx](https://github.com/xZepyx) |
 | **C#** | [ToonEncoder](https://github.com/Cysharp/ToonEncoder) | [@Cysharp](https://github.com/Cysharp/ToonEncoder) |
 | **Clojure** | [toon](https://github.com/vadelabs/toon) | [@vadelabs](https://github.com/vadelabs) |
 | **Crystal** | [toon-crystal](https://github.com/mamantoha/toon-crystal) | [@mamantoha](https://github.com/mamantoha) |


### PR DESCRIPTION
## Linked Issue

Closes #

## Description

Adds a header-only C++ implementation of TOON to the "Implementations" table.

Repository: https://github.com/xZepyx/toon.hpp

This implementation focuses on:

* Single-header design (`toon.hpp`)
* No external dependencies
* Lightweight parsing and serialization
* Simple API for embedding in small C++ projects
* No need to build or link any libs.

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] Documentation update
* [ ] New feature
* [ ] Breaking change
* [ ] Refactoring
* [ ] Performance improvement
* [ ] Test coverage improvement

## Changes Made

* Added a new row in the Implementations table for a C++ header-only implementation.
* Linked the repository and maintainer.

## SPEC Compliance

* [ ] This PR implements/fixes spec compliance

## Testing

* [x] All existing tests pass

## Pre-submission Checklist

* [x] I have updated documentation if needed
* [x] I have reviewed the TOON specification for relevant sections

## Breaking Changes

* [x] No breaking changes

## Additional Context

This PR only adds a reference to an external implementation and does not modify the specification itself.
