### PR TITLE
feat: add reviver option for decode

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -413,6 +413,107 @@ const value = decodeFromLines(rl)
 console.log(value)
 ```
 
+### Reviver Function
+
+The `reviver` option allows you to transform or filter values during decoding. It works similarly to `JSON.parse`'s reviver parameter, but with path tracking for more precise control.
+
+#### Type Signature
+
+```typescript
+type DecodeReviver = (
+  key: string,
+  value: JsonValue,
+  path: readonly (string | number)[]
+) => unknown
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `key` | `string` | Property name, array index (as string), or empty string for root |
+| `value` | `JsonValue` | The decoded value at this location |
+| `path` | `readonly (string \| number)[]` | Path from root to current value |
+
+#### Return Value
+
+- Return the value unchanged to keep it
+- Return a different value to replace it (will be normalized)
+- Return `undefined` to omit properties/array elements
+- For root value, `undefined` means "no change" (root cannot be omitted)
+
+#### Examples
+
+**Filtering sensitive data:**
+
+```typescript
+import { decode } from '@toon-format/toon'
+
+const toon = `user:
+  name: Alice
+  password: secret123
+  email: alice@example.com`
+
+function reviver(key, value) {
+  if (key === 'password')
+    return undefined
+  return value
+}
+
+console.log(decode(toon, { reviver }))
+// { user: { name: 'Alice', email: 'alice@example.com' } }
+```
+
+**Transforming values:**
+
+```typescript
+const toon = `user: alice
+role: admin`
+
+function reviver(key, value) {
+  if (typeof value === 'string')
+    return value.toUpperCase()
+  return value
+}
+
+console.log(decode(toon, { reviver }))
+// { user: 'ALICE', role: 'ADMIN' }
+```
+
+**Path-based transformations:**
+
+```typescript
+const toon = `metadata:
+  created: 2025-01-01
+user:
+  created: 2025-01-02`
+
+function reviver(key, value, path) {
+  // Add timezone info only to top-level metadata
+  if (path.length === 2 && path[0] === 'metadata' && key === 'created') {
+    return `${value}T00:00:00Z`
+  }
+  return value
+}
+
+console.log(decode(toon, { reviver }))
+// {
+//   metadata: { created: '2025-01-01T00:00:00Z' },
+//   user: { created: '2025-01-02' }
+// }
+```
+
+::: tip Reviver Execution Order
+The reviver is called in a depth-first, bottom-up manner:
+1. Each property/element is processed after its children
+2. The root value is processed last (key = `''`, path = `[]`)
+3. Values are normalized after replacement
+:::
+
+::: warning Array Indices as Strings
+Following `JSON.parse` behavior, array indices are passed as strings (`'0'`, `'1'`, `'2'`, etc.) to the reviver, not as numbers.
+:::
+
 ### Choosing the Right Decoder
 
 | Function | Input | Output | Async | Use When |
@@ -610,6 +711,7 @@ Configuration for [`decode()`](#decode-input-options) and [`decodeFromLines()`](
 |--------|------|---------|-------------|
 | `indentSize` | `number` | `2` | Expected number of spaces per indentation level |
 | `strict` | `boolean` | `true` | Enable strict validation (array counts, indentation, delimiter consistency) |
+| `reviver` | `DecodeReviver` | `undefined` | Optional hook to transform or omit values after decoding (see [Reviver Function](#reviver-function)) |
 
 By default (`strict: true`), the decoder validates input strictly:
 

--- a/packages/toon/src/decode/reviver.ts
+++ b/packages/toon/src/decode/reviver.ts
@@ -1,0 +1,168 @@
+import type { DecodeReviver, JsonArray, JsonObject, JsonValue } from '../types.ts'
+
+/**
+ * Applies a reviver function to a `JsonValue` and all its descendants.
+ *
+ * The reviver is called bottom-up (leaves first, then parents), matching
+ * `JSON.parse` reviver semantics:
+ * - Every object property (with the property name as key)
+ * - Every array element (with the string index as key: '0', '1', etc.)
+ * - The root value (with key='', path=[]) last
+ *
+ * @param root - The decoded `JsonValue` to transform
+ * @param reviver - The reviver function to apply
+ * @returns The transformed `JsonValue`
+ */
+export function applyReviver(root: JsonValue, reviver: DecodeReviver): JsonValue {
+  // First, recursively transform children (bottom-up)
+  const transformed = transformChildren(root, reviver, [])
+
+  // Then call reviver on root with empty string key and empty path
+  const revivedRoot = reviver('', transformed, [])
+
+  // For root, undefined means "no change" (don't omit the root)
+  if (revivedRoot === undefined) {
+    return transformed
+  }
+
+  return normalizeRevivedValue(revivedRoot)
+}
+
+/**
+ * Recursively transforms the children of a `JsonValue` using the reviver.
+ * Children are transformed before their parents (bottom-up).
+ *
+ * @param value - The value whose children should be transformed
+ * @param reviver - The reviver function to apply
+ * @param path - Current path from root
+ * @returns The value with transformed children
+ */
+function transformChildren(
+  value: JsonValue,
+  reviver: DecodeReviver,
+  path: readonly (string | number)[],
+): JsonValue {
+  if (isJsonObject(value)) {
+    return transformObject(value, reviver, path)
+  }
+
+  if (isJsonArray(value)) {
+    return transformArray(value, reviver, path)
+  }
+
+  // Primitives have no children
+  return value
+}
+
+/**
+ * Transforms an object by applying the reviver to each property (bottom-up).
+ *
+ * @param obj - The object to transform
+ * @param reviver - The reviver function to apply
+ * @param path - Current path from root
+ * @returns A new object with transformed properties
+ */
+function transformObject(
+  obj: JsonObject,
+  reviver: DecodeReviver,
+  path: readonly (string | number)[],
+): JsonObject {
+  const result: Record<string, JsonValue> = {}
+
+  for (const [key, value] of Object.entries(obj)) {
+    const childPath = [...path, key]
+
+    // First, recursively transform children of this value (bottom-up)
+    const transformedValue = transformChildren(value, reviver, childPath)
+
+    // Then call reviver on this property
+    const revivedValue = reviver(key, transformedValue, childPath)
+
+    // undefined means omit this property
+    if (revivedValue === undefined) {
+      continue
+    }
+
+    result[key] = normalizeRevivedValue(revivedValue)
+  }
+
+  return result
+}
+
+/**
+ * Transforms an array by applying the reviver to each element (bottom-up).
+ *
+ * @param arr - The array to transform
+ * @param reviver - The reviver function to apply
+ * @param path - Current path from root
+ * @returns A new array with transformed elements
+ */
+function transformArray(
+  arr: JsonArray,
+  reviver: DecodeReviver,
+  path: readonly (string | number)[],
+): JsonArray {
+  const result: JsonValue[] = []
+
+  for (let i = 0; i < arr.length; i++) {
+    const value = arr[i]!
+    const childPath = [...path, i]
+
+    // First, recursively transform children of this value (bottom-up)
+    const transformedValue = transformChildren(value, reviver, childPath)
+
+    // Then call reviver with string index to match JSON.parse behavior
+    const revivedValue = reviver(String(i), transformedValue, childPath)
+
+    // undefined means omit this element
+    if (revivedValue === undefined) {
+      continue
+    }
+
+    result.push(normalizeRevivedValue(revivedValue))
+  }
+
+  return result
+}
+
+/**
+ * Normalizes a revived value back to a `JsonValue`.
+ * Handles common non-JSON returns (Date, undefined, etc.).
+ */
+function normalizeRevivedValue(value: unknown): JsonValue {
+  if (value === null)
+    return null
+  if (typeof value === 'string')
+    return value
+  if (typeof value === 'number')
+    return value
+  if (typeof value === 'boolean')
+    return value
+
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(v => normalizeRevivedValue(v))
+  }
+
+  if (typeof value === 'object') {
+    const result: Record<string, JsonValue> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = normalizeRevivedValue(v)
+    }
+    return result
+  }
+
+  // Fallback: convert to string
+  return String(value)
+}
+
+function isJsonObject(value: JsonValue): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isJsonArray(value: JsonValue): value is JsonArray {
+  return Array.isArray(value)
+}

--- a/packages/toon/src/decode/reviver.ts
+++ b/packages/toon/src/decode/reviver.ts
@@ -1,0 +1,127 @@
+import type { DecodeReviver, JsonArray, JsonObject, JsonValue } from '../types.ts'
+import { isJsonArray, isJsonObject, normalizeValue } from '../encode/normalize.ts'
+
+/**
+ * Applies a reviver function to a `JsonValue` and all its descendants.
+ *
+ * The reviver is called bottom-up (leaves first, then parents), matching
+ * `JSON.parse` reviver semantics:
+ * - Every object property (with the property name as key)
+ * - Every array element (with the string index as key: '0', '1', etc.)
+ * - The root value (with key='', path=[]) last
+ *
+ * @param root - The decoded `JsonValue` to transform
+ * @param reviver - The reviver function to apply
+ * @returns The transformed `JsonValue`
+ */
+export function applyReviver(root: JsonValue, reviver: DecodeReviver): JsonValue {
+  // First, recursively transform children (bottom-up)
+  const transformed = transformChildren(root, reviver, [])
+
+  // Then call reviver on root with empty string key and empty path
+  const revivedRoot = reviver('', transformed, [])
+
+  // For root, undefined means "no change" (don't omit the root)
+  if (revivedRoot === undefined) {
+    return transformed
+  }
+
+  return normalizeValue(revivedRoot)
+}
+
+/**
+ * Recursively transforms the children of a `JsonValue` using the reviver.
+ * Children are transformed before their parents (bottom-up).
+ *
+ * @param value - The value whose children should be transformed
+ * @param reviver - The reviver function to apply
+ * @param path - Current path from root
+ * @returns The value with transformed children
+ */
+function transformChildren(
+  value: JsonValue,
+  reviver: DecodeReviver,
+  path: readonly (string | number)[],
+): JsonValue {
+  if (isJsonObject(value)) {
+    return transformObject(value, reviver, path)
+  }
+
+  if (isJsonArray(value)) {
+    return transformArray(value, reviver, path)
+  }
+
+  // Primitives have no children
+  return value
+}
+
+/**
+ * Transforms an object by applying the reviver to each property (bottom-up).
+ *
+ * @param obj - The object to transform
+ * @param reviver - The reviver function to apply
+ * @param path - Current path from root
+ * @returns A new object with transformed properties
+ */
+function transformObject(
+  obj: JsonObject,
+  reviver: DecodeReviver,
+  path: readonly (string | number)[],
+): JsonObject {
+  const result: Record<string, JsonValue> = {}
+
+  for (const [key, value] of Object.entries(obj)) {
+    const childPath = [...path, key]
+
+    // First, recursively transform children of this value (bottom-up)
+    const transformedValue = transformChildren(value, reviver, childPath)
+
+    // Then call reviver on this property
+    const revivedValue = reviver(key, transformedValue, childPath)
+
+    // undefined means omit this property
+    if (revivedValue === undefined) {
+      continue
+    }
+
+    result[key] = normalizeValue(revivedValue)
+  }
+
+  return result
+}
+
+/**
+ * Transforms an array by applying the reviver to each element (bottom-up).
+ *
+ * @param arr - The array to transform
+ * @param reviver - The reviver function to apply
+ * @param path - Current path from root
+ * @returns A new array with transformed elements
+ */
+function transformArray(
+  arr: JsonArray,
+  reviver: DecodeReviver,
+  path: readonly (string | number)[],
+): JsonArray {
+  const result: JsonValue[] = []
+
+  for (let i = 0; i < arr.length; i++) {
+    const value = arr[i]!
+    const childPath = [...path, i]
+
+    // First, recursively transform children of this value (bottom-up)
+    const transformedValue = transformChildren(value, reviver, childPath)
+
+    // Then call reviver with string index to match JSON.parse behavior
+    const revivedValue = reviver(String(i), transformedValue, childPath)
+
+    // undefined means omit this element
+    if (revivedValue === undefined) {
+      continue
+    }
+
+    result.push(normalizeValue(revivedValue))
+  }
+
+  return result
+}

--- a/packages/toon/src/index.ts
+++ b/packages/toon/src/index.ts
@@ -3,6 +3,7 @@ import { DEFAULT_DELIMITER } from './constants.ts'
 import { decodeStream as decodeStreamCore, decodeStreamSync as decodeStreamSyncCore } from './decode/decoders.ts'
 import { buildValueFromEvents } from './decode/event-builder.ts'
 import { expandPathsSafe } from './decode/expand.ts'
+import { applyReviver } from './decode/reviver.ts'
 import { encodeJsonValue } from './encode/encoders.ts'
 import { normalizeValue } from './encode/normalize.ts'
 import { applyReplacer } from './encode/replacer.ts'
@@ -10,6 +11,7 @@ import { applyReplacer } from './encode/replacer.ts'
 export { DEFAULT_DELIMITER, DELIMITERS } from './constants.ts'
 export type {
   DecodeOptions,
+  DecodeReviver,
   DecodeStreamOptions,
   Delimiter,
   DelimiterKey,
@@ -136,11 +138,16 @@ export function decodeFromLines(lines: Iterable<string>, options?: DecodeOptions
   }
 
   const events = decodeStreamSyncCore(lines, streamOptions)
-  const decodedValue = buildValueFromEvents(events)
+  let decodedValue = buildValueFromEvents(events)
 
   // Apply path expansion if enabled
   if (resolvedOptions.expandPaths === 'safe') {
-    return expandPathsSafe(decodedValue, resolvedOptions.strict)
+    decodedValue = expandPathsSafe(decodedValue, resolvedOptions.strict)
+  }
+
+  // Apply reviver if provided
+  if (resolvedOptions.reviver) {
+    return applyReviver(decodedValue, resolvedOptions.reviver)
   }
 
   return decodedValue
@@ -227,5 +234,6 @@ function resolveDecodeOptions(options?: DecodeOptions): ResolvedDecodeOptions {
     indent: options?.indent ?? 2,
     strict: options?.strict ?? true,
     expandPaths: options?.expandPaths ?? 'off',
+    reviver: options?.reviver,
   }
 }

--- a/packages/toon/src/index.ts
+++ b/packages/toon/src/index.ts
@@ -2,6 +2,7 @@ import type { DecodeOptions, DecodeStreamOptions, EncodeOptions, JsonStreamEvent
 import { DEFAULT_DELIMITER } from './constants.ts'
 import { decodeStream as decodeStreamCore, decodeStreamSync as decodeStreamSyncCore } from './decode/decoders.ts'
 import { buildValueFromEvents } from './decode/event-builder.ts'
+import { applyReviver } from './decode/reviver.ts'
 import { encodeJsonValue } from './encode/encoders.ts'
 import { normalizeValue } from './encode/normalize.ts'
 import { applyReplacer } from './encode/replacer.ts'
@@ -14,6 +15,7 @@ export type { RawString } from './encode/raw-string.ts'
 export { escapeString } from './shared/string-utils.ts'
 export type {
   DecodeOptions,
+  DecodeReviver,
   DecodeStreamOptions,
   Delimiter,
   DelimiterKey,
@@ -137,7 +139,13 @@ export function encodeLines(input: unknown, options?: EncodeOptions): Iterable<s
 export function decodeFromLines(lines: Iterable<string>, options?: DecodeOptions): JsonValue {
   const resolvedOptions = resolveDecodeOptions(options)
   const events = decodeStreamSyncCore(lines, resolvedOptions)
-  return buildValueFromEvents(events)
+  const decodedValue = buildValueFromEvents(events)
+
+  if (resolvedOptions.reviver) {
+    return applyReviver(decodedValue, resolvedOptions.reviver)
+  }
+
+  return decodedValue
 }
 
 /**
@@ -213,5 +221,6 @@ function resolveDecodeOptions(options?: DecodeOptions): ResolvedDecodeOptions {
   return {
     indentSize: options?.indentSize ?? options?.indent ?? 2,
     strict: options?.strict ?? true,
+    reviver: options?.reviver,
   }
 }

--- a/packages/toon/src/types.ts
+++ b/packages/toon/src/types.ts
@@ -89,6 +89,43 @@ export type ResolvedEncodeOptions = Readonly<Required<Omit<EncodeOptions, 'repla
 
 // #region Decoder options
 
+/**
+ * A function that transforms or filters values during decoding.
+ *
+ * Called for every value (root, object properties, array elements) after the decode is complete.
+ * Similar to `JSON.parse`'s reviver, but with path tracking.
+ *
+ * Values are visited bottom-up: leaf values first, then their parent containers.
+ *
+ * @param key - The property key or array index (as string). Empty string (`''`) for root value.
+ * @param value - The decoded `JsonValue` at this location.
+ * @param path - Array representing the path from root to this value.
+ *
+ * @returns The replacement value, or `undefined` to omit.
+ *          For root value, returning `undefined` means "no change" (don't omit root).
+ *
+ * @example
+ * ```ts
+ * // Parse date strings into Date-like objects
+ * const reviver = (key, value) => {
+ *   if (key === 'createdAt' && typeof value === 'string')
+ *     return { _date: value }
+ *   return value
+ * }
+ *
+ * // Remove internal fields
+ * const reviver = (key, value) => {
+ *   if (key.startsWith('_')) return undefined
+ *   return value
+ * }
+ * ```
+ */
+export type DecodeReviver = (
+  key: string,
+  value: JsonValue,
+  path: readonly (string | number)[],
+) => unknown
+
 export interface DecodeOptions {
   /**
    * Number of spaces per indentation level.
@@ -108,9 +145,17 @@ export interface DecodeOptions {
    * @default 'off'
    */
   expandPaths?: 'off' | 'safe'
+  /**
+   * A function to transform or filter values during decoding.
+   * Called for the root value and every nested property/element after decoding.
+   * Values are visited bottom-up (leaves first, then parents).
+   * Return `undefined` to omit properties/elements (root cannot be omitted).
+   * @default undefined
+   */
+  reviver?: DecodeReviver
 }
 
-export type ResolvedDecodeOptions = Readonly<Required<DecodeOptions>>
+export type ResolvedDecodeOptions = Readonly<Required<Omit<DecodeOptions, 'reviver'>>> & Pick<DecodeOptions, 'reviver'>
 
 /**
  * Options for streaming decode operations.

--- a/packages/toon/src/types.ts
+++ b/packages/toon/src/types.ts
@@ -79,6 +79,43 @@ export type ResolvedEncodeOptions = Readonly<Required<Omit<EncodeOptions, 'repla
 
 // #region Decoder options
 
+/**
+ * A function that transforms or filters values during decoding.
+ *
+ * Called for every value (root, object properties, array elements) after the decode is complete.
+ * Similar to `JSON.parse`'s reviver, but with path tracking.
+ *
+ * Values are visited bottom-up: leaf values first, then their parent containers.
+ *
+ * @param key - The property key or array index (as string). Empty string (`''`) for root value.
+ * @param value - The decoded `JsonValue` at this location.
+ * @param path - Array representing the path from root to this value.
+ *
+ * @returns The replacement value, or `undefined` to omit.
+ *          For root value, returning `undefined` means "no change" (don't omit root).
+ *
+ * @example
+ * ```ts
+ * // Parse date strings into Date-like objects
+ * const reviver = (key, value) => {
+ *   if (key === 'createdAt' && typeof value === 'string')
+ *     return { _date: value }
+ *   return value
+ * }
+ *
+ * // Remove internal fields
+ * const reviver = (key, value) => {
+ *   if (key.startsWith('_')) return undefined
+ *   return value
+ * }
+ * ```
+ */
+export type DecodeReviver = (
+  key: string,
+  value: JsonValue,
+  path: readonly (string | number)[],
+) => unknown
+
 export interface DecodeOptions {
   /**
    * Number of spaces per indentation level.
@@ -94,9 +131,17 @@ export interface DecodeOptions {
    * @default true
    */
   strict?: boolean
+  /**
+   * A function to transform or filter values during decoding.
+   * Called for the root value and every nested property/element after decoding.
+   * Values are visited bottom-up (leaves first, then parents).
+   * Return `undefined` to omit properties/elements (root cannot be omitted).
+   * @default undefined
+   */
+  reviver?: DecodeReviver
 }
 
-export type ResolvedDecodeOptions = Readonly<Required<Omit<DecodeOptions, 'indent'>>>
+export type ResolvedDecodeOptions = Readonly<Required<Omit<DecodeOptions, 'indent' | 'reviver'>>> & Pick<DecodeOptions, 'reviver'>
 
 /** Options for streaming decode operations. */
 export type DecodeStreamOptions = DecodeOptions

--- a/packages/toon/test/reviver.test.ts
+++ b/packages/toon/test/reviver.test.ts
@@ -1,0 +1,367 @@
+import type { DecodeReviver, JsonObject } from '../src/types'
+import { describe, expect, it } from 'vitest'
+import { decode, encode } from '../src/index'
+
+describe('reviver function', () => {
+  describe('basic filtering', () => {
+    it('removes properties by returning undefined', () => {
+      const input = { name: 'Alice', password: 'secret', email: 'alice@example.com' }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'password')
+          return undefined
+        return value
+      }
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({ name: 'Alice', email: 'alice@example.com' })
+      expect(result).not.toHaveProperty('password')
+    })
+
+    it('removes array elements by returning undefined', () => {
+      const input = { items: [1, 2, 3, 4, 5] }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (typeof value === 'number' && value % 2 === 0)
+          return undefined
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(result.items).toEqual([1, 3, 5])
+    })
+
+    it('handles deeply nested filtering', () => {
+      const input = {
+        users: [
+          { name: 'Alice', password: 'secret1', role: 'admin' },
+          { name: 'Bob', password: 'secret2', role: 'user' },
+        ],
+      }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'password')
+          return undefined
+        return value
+      }
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({
+        users: [
+          { name: 'Alice', role: 'admin' },
+          { name: 'Bob', role: 'user' },
+        ],
+      })
+    })
+  })
+
+  describe('value transformation', () => {
+    it('transforms primitive values', () => {
+      const input = { name: 'alice', age: 30 }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'name' && typeof value === 'string')
+          return value.toUpperCase()
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(result.name).toBe('ALICE')
+      expect(result.age).toBe(30)
+    })
+
+    it('transforms objects by adding properties', () => {
+      const input = { user: { name: 'Alice' } }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'user' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          return { ...value as object, _processed: true }
+        }
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(result.user).toEqual({ name: 'Alice', _processed: true })
+    })
+
+    it('transforms number values', () => {
+      const input = { numbers: [1, 2, 3] }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (typeof value === 'number')
+          return value * 2
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(result.numbers).toEqual([2, 4, 6])
+    })
+  })
+
+  describe('root value handling', () => {
+    it('calls reviver on root value with empty string key', () => {
+      const input = { value: 42 }
+      const toon = encode(input)
+      let rootKeySeen = false
+      let rootPathSeen = false
+
+      const reviver: DecodeReviver = (key, value, path) => {
+        if (key === '' && path.length === 0) {
+          rootKeySeen = true
+          rootPathSeen = true
+        }
+        return value
+      }
+
+      decode(toon, { reviver })
+
+      expect(rootKeySeen).toBe(true)
+      expect(rootPathSeen).toBe(true)
+    })
+
+    it('transforms root object', () => {
+      const input = { name: 'Alice' }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value, path) => {
+        if (path.length === 0 && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          return { ...value as object, _decoded: true }
+        }
+        return value
+      }
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({ name: 'Alice', _decoded: true })
+    })
+
+    it('does not omit root when reviver returns undefined', () => {
+      const input = { name: 'Alice' }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value, path) => {
+        if (path.length === 0)
+          return undefined
+        return value
+      }
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({ name: 'Alice' })
+    })
+  })
+
+  describe('bottom-up traversal', () => {
+    it('visits leaves before parents', () => {
+      const input = { parent: { child: 'leaf' } }
+      const toon = encode(input)
+      const visitOrder: string[] = []
+
+      const reviver: DecodeReviver = (key, value) => {
+        if (key !== '')
+          visitOrder.push(key)
+        return value
+      }
+
+      decode(toon, { reviver })
+
+      // child should be visited before parent
+      expect(visitOrder.indexOf('child')).toBeLessThan(visitOrder.indexOf('parent'))
+    })
+
+    it('visits array elements before the array container key', () => {
+      const input = { items: ['a', 'b'] }
+      const toon = encode(input)
+      const visitOrder: string[] = []
+
+      const reviver: DecodeReviver = (key, value) => {
+        if (key !== '')
+          visitOrder.push(key)
+        return value
+      }
+
+      decode(toon, { reviver })
+
+      // array elements (0, 1) should be visited before 'items'
+      expect(visitOrder.indexOf('0')).toBeLessThan(visitOrder.indexOf('items'))
+      expect(visitOrder.indexOf('1')).toBeLessThan(visitOrder.indexOf('items'))
+    })
+  })
+
+  describe('path tracking', () => {
+    it('provides correct paths for nested objects', () => {
+      const input = { user: { profile: { name: 'Alice' } } }
+      const toon = encode(input)
+      const paths: string[] = []
+
+      const reviver: DecodeReviver = (key, value, path) => {
+        paths.push(path.join('.'))
+        return value
+      }
+
+      decode(toon, { reviver })
+
+      expect(paths).toContain('')
+      expect(paths).toContain('user')
+      expect(paths).toContain('user.profile')
+      expect(paths).toContain('user.profile.name')
+    })
+
+    it('provides correct paths for arrays with numeric indices', () => {
+      const input = { items: ['a', 'b', 'c'] }
+      const toon = encode(input)
+      const seenKeys: string[] = []
+
+      const reviver: DecodeReviver = (key, value) => {
+        if (typeof value === 'string')
+          seenKeys.push(key)
+        return value
+      }
+
+      decode(toon, { reviver })
+      expect(seenKeys).toEqual(['0', '1', '2'])
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles null values', () => {
+      const input = { value: null }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (value === null)
+          return 'WAS_NULL'
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(result.value).toBe('WAS_NULL')
+    })
+
+    it('handles empty objects', () => {
+      const input = { data: {} }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => value
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({ data: {} })
+    })
+
+    it('normalizes non-JsonValue returns', () => {
+      const input = { date: '2025-01-01T00:00:00.000Z' }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'date' && typeof value === 'string')
+          return new Date(value)
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(typeof result.date).toBe('string')
+      expect(result.date).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    it('handles all properties being filtered out', () => {
+      const input = { a: 1, b: 2, c: 3 }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (_key, value, path) => {
+        if (path.length > 0)
+          return undefined
+        return value
+      }
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({})
+    })
+  })
+
+  describe('roundtrip with replacer', () => {
+    it('replacer and reviver compose correctly', () => {
+      const input = { name: 'Alice', age: 30, role: 'admin' }
+
+      // Encode with replacer that uppercases strings
+      const toon = encode(input, {
+        replacer: (key, value) => {
+          if (typeof value === 'string')
+            return value.toUpperCase()
+          return value
+        },
+      })
+
+      // Decode with reviver that lowercases strings
+      const result = decode(toon, {
+        reviver: (key, value) => {
+          if (typeof value === 'string')
+            return value.toLowerCase()
+          return value
+        },
+      })
+
+      expect(result).toEqual({ name: 'alice', age: 30, role: 'admin' })
+    })
+  })
+
+  describe('comparison with JSON.parse reviver', () => {
+    it('behaves similarly to JSON.parse for filtering', () => {
+      const input = { name: 'Alice', password: 'secret' }
+      const toon = encode(input)
+
+      const toonReviver: DecodeReviver = (key, value) => {
+        if (key === 'password')
+          return undefined
+        return value
+      }
+
+      const jsonReviver = (key: string, value: unknown) => {
+        if (key === 'password')
+          return undefined
+        return value
+      }
+
+      const toonResult = decode(toon, { reviver: toonReviver })
+      const jsonResult = JSON.parse(JSON.stringify(input), jsonReviver)
+
+      expect(toonResult).toEqual(jsonResult)
+    })
+
+    it('uses string indices for arrays like JSON.parse', () => {
+      const input = { items: ['a', 'b', 'c'] }
+      const toon = encode(input)
+      const keys: string[] = []
+
+      const reviver: DecodeReviver = (key, value) => {
+        if (typeof value === 'string')
+          keys.push(key)
+        return value
+      }
+
+      decode(toon, { reviver })
+      expect(keys).toEqual(['0', '1', '2'])
+    })
+  })
+
+  describe('integration with other decode options', () => {
+    it('works with expandPaths', () => {
+      const input = { 'user.name': 'Alice', 'user.age': 30 }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'name' && typeof value === 'string')
+          return value.toUpperCase()
+        return value
+      }
+
+      const result = decode(toon, { expandPaths: 'safe', reviver }) as JsonObject
+      const user = result.user as JsonObject
+      expect(user.name).toBe('ALICE')
+      expect(user.age).toBe(30)
+    })
+
+    it('works with strict mode disabled', () => {
+      const input = { items: [1, 2, 3] }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (typeof value === 'number')
+          return value * 10
+        return value
+      }
+
+      const result = decode(toon, { strict: false, reviver }) as JsonObject
+      expect(result.items).toEqual([10, 20, 30])
+    })
+  })
+})

--- a/packages/toon/test/reviver.test.ts
+++ b/packages/toon/test/reviver.test.ts
@@ -1,0 +1,352 @@
+import type { DecodeReviver, JsonObject } from '../src/types'
+import { describe, expect, it } from 'vitest'
+import { decode, encode } from '../src/index'
+
+describe('reviver function', () => {
+  describe('basic filtering', () => {
+    it('removes properties by returning undefined', () => {
+      const input = { name: 'Alice', password: 'secret', email: 'alice@example.com' }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'password')
+          return undefined
+        return value
+      }
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({ name: 'Alice', email: 'alice@example.com' })
+      expect(result).not.toHaveProperty('password')
+    })
+
+    it('removes array elements by returning undefined', () => {
+      const input = { items: [1, 2, 3, 4, 5] }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (typeof value === 'number' && value % 2 === 0)
+          return undefined
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(result.items).toEqual([1, 3, 5])
+    })
+
+    it('handles deeply nested filtering', () => {
+      const input = {
+        users: [
+          { name: 'Alice', password: 'secret1', role: 'admin' },
+          { name: 'Bob', password: 'secret2', role: 'user' },
+        ],
+      }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'password')
+          return undefined
+        return value
+      }
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({
+        users: [
+          { name: 'Alice', role: 'admin' },
+          { name: 'Bob', role: 'user' },
+        ],
+      })
+    })
+  })
+
+  describe('value transformation', () => {
+    it('transforms primitive values', () => {
+      const input = { name: 'alice', age: 30 }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'name' && typeof value === 'string')
+          return value.toUpperCase()
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(result.name).toBe('ALICE')
+      expect(result.age).toBe(30)
+    })
+
+    it('transforms objects by adding properties', () => {
+      const input = { user: { name: 'Alice' } }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'user' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          return { ...value as object, _processed: true }
+        }
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(result.user).toEqual({ name: 'Alice', _processed: true })
+    })
+
+    it('transforms number values', () => {
+      const input = { numbers: [1, 2, 3] }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (typeof value === 'number')
+          return value * 2
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(result.numbers).toEqual([2, 4, 6])
+    })
+  })
+
+  describe('root value handling', () => {
+    it('calls reviver on root value with empty string key', () => {
+      const input = { value: 42 }
+      const toon = encode(input)
+      let rootKeySeen = false
+      let rootPathSeen = false
+
+      const reviver: DecodeReviver = (key, value, path) => {
+        if (key === '' && path.length === 0) {
+          rootKeySeen = true
+          rootPathSeen = true
+        }
+        return value
+      }
+
+      decode(toon, { reviver })
+
+      expect(rootKeySeen).toBe(true)
+      expect(rootPathSeen).toBe(true)
+    })
+
+    it('transforms root object', () => {
+      const input = { name: 'Alice' }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value, path) => {
+        if (path.length === 0 && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          return { ...value as object, _decoded: true }
+        }
+        return value
+      }
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({ name: 'Alice', _decoded: true })
+    })
+
+    it('does not omit root when reviver returns undefined', () => {
+      const input = { name: 'Alice' }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value, path) => {
+        if (path.length === 0)
+          return undefined
+        return value
+      }
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({ name: 'Alice' })
+    })
+  })
+
+  describe('bottom-up traversal', () => {
+    it('visits leaves before parents', () => {
+      const input = { parent: { child: 'leaf' } }
+      const toon = encode(input)
+      const visitOrder: string[] = []
+
+      const reviver: DecodeReviver = (key, value) => {
+        if (key !== '')
+          visitOrder.push(key)
+        return value
+      }
+
+      decode(toon, { reviver })
+
+      // child should be visited before parent
+      expect(visitOrder.indexOf('child')).toBeLessThan(visitOrder.indexOf('parent'))
+    })
+
+    it('visits array elements before the array container key', () => {
+      const input = { items: ['a', 'b'] }
+      const toon = encode(input)
+      const visitOrder: string[] = []
+
+      const reviver: DecodeReviver = (key, value) => {
+        if (key !== '')
+          visitOrder.push(key)
+        return value
+      }
+
+      decode(toon, { reviver })
+
+      // array elements (0, 1) should be visited before 'items'
+      expect(visitOrder.indexOf('0')).toBeLessThan(visitOrder.indexOf('items'))
+      expect(visitOrder.indexOf('1')).toBeLessThan(visitOrder.indexOf('items'))
+    })
+  })
+
+  describe('path tracking', () => {
+    it('provides correct paths for nested objects', () => {
+      const input = { user: { profile: { name: 'Alice' } } }
+      const toon = encode(input)
+      const paths: string[] = []
+
+      const reviver: DecodeReviver = (key, value, path) => {
+        paths.push(path.join('.'))
+        return value
+      }
+
+      decode(toon, { reviver })
+
+      expect(paths).toContain('')
+      expect(paths).toContain('user')
+      expect(paths).toContain('user.profile')
+      expect(paths).toContain('user.profile.name')
+    })
+
+    it('provides correct paths for arrays with numeric indices', () => {
+      const input = { items: ['a', 'b', 'c'] }
+      const toon = encode(input)
+      const seenKeys: string[] = []
+
+      const reviver: DecodeReviver = (key, value) => {
+        if (typeof value === 'string')
+          seenKeys.push(key)
+        return value
+      }
+
+      decode(toon, { reviver })
+      expect(seenKeys).toEqual(['0', '1', '2'])
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles null values', () => {
+      const input = { value: null }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (value === null)
+          return 'WAS_NULL'
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(result.value).toBe('WAS_NULL')
+    })
+
+    it('handles empty objects', () => {
+      const input = { data: {} }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => value
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({ data: {} })
+    })
+
+    it('normalizes non-JsonValue returns', () => {
+      const input = { date: '2025-01-01T00:00:00.000Z' }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (key === 'date' && typeof value === 'string')
+          return new Date(value)
+        return value
+      }
+
+      const result = decode(toon, { reviver }) as JsonObject
+      expect(typeof result.date).toBe('string')
+      expect(result.date).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    it('handles all properties being filtered out', () => {
+      const input = { a: 1, b: 2, c: 3 }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (_key, value, path) => {
+        if (path.length > 0)
+          return undefined
+        return value
+      }
+
+      const result = decode(toon, { reviver })
+      expect(result).toEqual({})
+    })
+  })
+
+  describe('roundtrip with replacer', () => {
+    it('replacer and reviver compose correctly', () => {
+      const input = { name: 'Alice', age: 30, role: 'admin' }
+
+      // Encode with replacer that uppercases strings
+      const toon = encode(input, {
+        replacer: (key, value) => {
+          if (typeof value === 'string')
+            return value.toUpperCase()
+          return value
+        },
+      })
+
+      // Decode with reviver that lowercases strings
+      const result = decode(toon, {
+        reviver: (key, value) => {
+          if (typeof value === 'string')
+            return value.toLowerCase()
+          return value
+        },
+      })
+
+      expect(result).toEqual({ name: 'alice', age: 30, role: 'admin' })
+    })
+  })
+
+  describe('comparison with JSON.parse reviver', () => {
+    it('behaves similarly to JSON.parse for filtering', () => {
+      const input = { name: 'Alice', password: 'secret' }
+      const toon = encode(input)
+
+      const toonReviver: DecodeReviver = (key, value) => {
+        if (key === 'password')
+          return undefined
+        return value
+      }
+
+      const jsonReviver = (key: string, value: unknown) => {
+        if (key === 'password')
+          return undefined
+        return value
+      }
+
+      const toonResult = decode(toon, { reviver: toonReviver })
+      const jsonResult = JSON.parse(JSON.stringify(input), jsonReviver)
+
+      expect(toonResult).toEqual(jsonResult)
+    })
+
+    it('uses string indices for arrays like JSON.parse', () => {
+      const input = { items: ['a', 'b', 'c'] }
+      const toon = encode(input)
+      const keys: string[] = []
+
+      const reviver: DecodeReviver = (key, value) => {
+        if (typeof value === 'string')
+          keys.push(key)
+        return value
+      }
+
+      decode(toon, { reviver })
+      expect(keys).toEqual(['0', '1', '2'])
+    })
+  })
+
+  describe('integration with other decode options', () => {
+    it('works with strict mode disabled', () => {
+      const input = { items: [1, 2, 3] }
+      const toon = encode(input)
+      const reviver: DecodeReviver = (key, value) => {
+        if (typeof value === 'number')
+          return value * 10
+        return value
+      }
+
+      const result = decode(toon, { strict: false, reviver }) as JsonObject
+      expect(result.items).toEqual([10, 20, 30])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `reviver` option to `DecodeOptions`, mirroring the existing `replacer` for `EncodeOptions`. The reviver transforms values during decode, matching `JSON.parse` reviver semantics (bottom-up traversal: leaves first, then parents).

## Why this matters

`JSON.stringify` has `replacer`, `JSON.parse` has `reviver`. TOON's `encode` already has `replacer`. The decode side had no equivalent, forcing users to walk the decoded tree manually for any post-decode transformation.

PR #161 (quoteStrings) was closed in favor of the general-purpose `replacer`, confirming the preference for general mechanisms over specific flags. `reviver` follows the same philosophy for the decode side.

## Usage

```ts
import { decode, encode } from '@toon-format/toon'

const toon = encode({ name: 'Alice', password: 'secret', role: 'admin' })

const result = decode(toon, {
  reviver: (key, value) => {
    if (key === 'password') return undefined
    if (key === 'name' && typeof value === 'string')
      return value.toUpperCase()
    return value
  }
})
// { name: 'ALICE', role: 'admin' }
```

## Changes

- `packages/toon/src/types.ts`: added `DecodeReviver` type and `reviver` option to `DecodeOptions`
- `packages/toon/src/decode/reviver.ts`: new module implementing bottom-up value traversal (mirrors `encode/replacer.ts`)
- `packages/toon/src/index.ts`: wired reviver into `decodeFromLines()`, exported `DecodeReviver` type
- `packages/toon/test/reviver.test.ts`: 22 tests covering filtering, transformation, root handling, bottom-up traversal, path tracking, edge cases, and JSON.parse parity

## Demo

![reviver demo](https://files.catbox.moe/grnm0z.gif)

## Testing

All 488 tests pass (22 new + 466 existing). Lint, build, and type checks clean.

This contribution was developed with AI assistance (Claude Code).