### PR TITLE
feat: add line numbers to decode errors

### DIFF
--- a/packages/toon/src/decode/decoders.ts
+++ b/packages/toon/src/decode/decoders.ts
@@ -8,6 +8,21 @@ import { assertExpectedCount, validateNoBlankLinesInRange, validateNoExtraListIt
 
 interface DecoderContext { indent: number, strict: boolean }
 
+/**
+ * Adds line number context to an error message if a line number is available.
+ * Preserves the original error type (SyntaxError, TypeError, etc.).
+ */
+function addLineContext(error: unknown, lineNumber?: number): unknown {
+  if (lineNumber == null || !(error instanceof Error))
+    return error
+  const suffix = ` (line ${lineNumber})`
+  if (error.message.includes(suffix))
+    return error
+  const newError = new (error.constructor as new (msg: string) => Error)(`${error.message}${suffix}`)
+  newError.stack = error.stack
+  return newError
+}
+
 // #region Streaming line cursor
 
 class StreamingLineCursor {
@@ -160,7 +175,7 @@ export function* decodeStreamSync(
 
   // Root object
   yield { type: 'startObject' }
-  yield* decodeKeyValueSync(first.content, cursor, 0, resolvedOptions)
+  yield* decodeKeyValueSync(first.content, cursor, 0, resolvedOptions, first.lineNumber)
 
   // Process remaining object fields
   while (!cursor.atEndSync()) {
@@ -170,7 +185,7 @@ export function* decodeStreamSync(
     }
 
     cursor.advanceSync()
-    yield* decodeKeyValueSync(line.content, cursor, 0, resolvedOptions)
+    yield* decodeKeyValueSync(line.content, cursor, 0, resolvedOptions, line.lineNumber)
   }
 
   yield { type: 'endObject' }
@@ -181,6 +196,7 @@ function* decodeKeyValueSync(
   cursor: StreamingLineCursor,
   baseDepth: Depth,
   options: DecoderContext,
+  lineNumber?: number,
 ): Generator<JsonStreamEvent> {
   // Check for array header first
   const arrayHeader = parseArrayHeaderLine(content, DEFAULT_DELIMITER)
@@ -191,7 +207,14 @@ function* decodeKeyValueSync(
   }
 
   // Regular key-value pair
-  const { key, isQuoted } = parseKeyToken(content, 0)
+  let keyResult: { key: string, isQuoted: boolean }
+  try {
+    keyResult = parseKeyToken(content, 0)
+  }
+  catch (error) {
+    throw addLineContext(error, lineNumber)
+  }
+  const { key, isQuoted } = keyResult
   const colonIndex = content.indexOf(COLON, key.length)
   const rest = colonIndex >= 0 ? content.slice(colonIndex + 1).trim() : ''
 
@@ -236,7 +259,7 @@ function* decodeObjectFieldsSync(
 
     if (line.depth === computedDepth) {
       cursor.advanceSync()
-      yield* decodeKeyValueSync(line.content, cursor, computedDepth, options)
+      yield* decodeKeyValueSync(line.content, cursor, computedDepth, options, line.lineNumber)
     }
     else {
       break
@@ -414,7 +437,7 @@ function* decodeListItemSync(
     afterHyphen = line.content.slice(LIST_ITEM_PREFIX.length)
   }
   else {
-    throw new SyntaxError(`Expected list item to start with "${LIST_ITEM_PREFIX}"`)
+    throw new SyntaxError(`Expected list item to start with "${LIST_ITEM_PREFIX}" (line ${line.lineNumber})`)
   }
 
   if (!afterHyphen.trim()) {
@@ -453,7 +476,7 @@ function* decodeListItemSync(
 
       if (nextLine.depth === followDepth && !nextLine.content.startsWith(LIST_ITEM_PREFIX)) {
         cursor.advanceSync()
-        yield* decodeKeyValueSync(nextLine.content, cursor, followDepth, options)
+        yield* decodeKeyValueSync(nextLine.content, cursor, followDepth, options, nextLine.lineNumber)
       }
       else {
         break
@@ -467,7 +490,7 @@ function* decodeListItemSync(
   // Check for object first field after hyphen
   if (isKeyValueContent(afterHyphen)) {
     yield { type: 'startObject' }
-    yield* decodeKeyValueSync(afterHyphen, cursor, baseDepth + 1, options)
+    yield* decodeKeyValueSync(afterHyphen, cursor, baseDepth + 1, options, line.lineNumber)
 
     // Read subsequent fields
     const followDepth = baseDepth + 1
@@ -479,7 +502,7 @@ function* decodeListItemSync(
 
       if (nextLine.depth === followDepth && !nextLine.content.startsWith(LIST_ITEM_PREFIX)) {
         cursor.advanceSync()
-        yield* decodeKeyValueSync(nextLine.content, cursor, followDepth, options)
+        yield* decodeKeyValueSync(nextLine.content, cursor, followDepth, options, nextLine.lineNumber)
       }
       else {
         break
@@ -562,7 +585,7 @@ export async function* decodeStream(
 
     // Root object
     yield { type: 'startObject' }
-    yield* decodeKeyValueAsync(first.content, cursor, 0, resolvedOptions)
+    yield* decodeKeyValueAsync(first.content, cursor, 0, resolvedOptions, first.lineNumber)
 
     // Process remaining object fields
     while (!(await cursor.atEnd())) {
@@ -571,7 +594,7 @@ export async function* decodeStream(
         break
       }
       await cursor.advance()
-      yield* decodeKeyValueAsync(line.content, cursor, 0, resolvedOptions)
+      yield* decodeKeyValueAsync(line.content, cursor, 0, resolvedOptions, line.lineNumber)
     }
 
     yield { type: 'endObject' }
@@ -587,6 +610,7 @@ async function* decodeKeyValueAsync(
   cursor: StreamingLineCursor,
   baseDepth: Depth,
   options: DecoderContext,
+  lineNumber?: number,
 ): AsyncGenerator<JsonStreamEvent> {
   // Check for array header first
   const arrayHeader = parseArrayHeaderLine(content, DEFAULT_DELIMITER)
@@ -597,7 +621,14 @@ async function* decodeKeyValueAsync(
   }
 
   // Regular key-value pair
-  const { key, isQuoted } = parseKeyToken(content, 0)
+  let keyResult: { key: string, isQuoted: boolean }
+  try {
+    keyResult = parseKeyToken(content, 0)
+  }
+  catch (error) {
+    throw addLineContext(error, lineNumber)
+  }
+  const { key, isQuoted } = keyResult
   const colonIndex = content.indexOf(COLON, key.length)
   const rest = colonIndex >= 0 ? content.slice(colonIndex + 1).trim() : ''
 
@@ -642,7 +673,7 @@ async function* decodeObjectFieldsAsync(
 
     if (line.depth === computedDepth) {
       await cursor.advance()
-      yield* decodeKeyValueAsync(line.content, cursor, computedDepth, options)
+      yield* decodeKeyValueAsync(line.content, cursor, computedDepth, options, line.lineNumber)
     }
     else {
       break
@@ -800,7 +831,7 @@ async function* decodeListItemAsync(
     afterHyphen = line.content.slice(LIST_ITEM_PREFIX.length)
   }
   else {
-    throw new SyntaxError(`Expected list item to start with "${LIST_ITEM_PREFIX}"`)
+    throw new SyntaxError(`Expected list item to start with "${LIST_ITEM_PREFIX}" (line ${line.lineNumber})`)
   }
 
   if (!afterHyphen.trim()) {
@@ -839,7 +870,7 @@ async function* decodeListItemAsync(
 
       if (nextLine.depth === followDepth && !nextLine.content.startsWith(LIST_ITEM_PREFIX)) {
         await cursor.advance()
-        yield* decodeKeyValueAsync(nextLine.content, cursor, followDepth, options)
+        yield* decodeKeyValueAsync(nextLine.content, cursor, followDepth, options, nextLine.lineNumber)
       }
       else {
         break
@@ -853,7 +884,7 @@ async function* decodeListItemAsync(
   // Check for object first field after hyphen
   if (isKeyValueContent(afterHyphen)) {
     yield { type: 'startObject' }
-    yield* decodeKeyValueAsync(afterHyphen, cursor, baseDepth + 1, options)
+    yield* decodeKeyValueAsync(afterHyphen, cursor, baseDepth + 1, options, line.lineNumber)
 
     // Read subsequent fields
     const followDepth = baseDepth + 1
@@ -865,7 +896,7 @@ async function* decodeListItemAsync(
 
       if (nextLine.depth === followDepth && !nextLine.content.startsWith(LIST_ITEM_PREFIX)) {
         await cursor.advance()
-        yield* decodeKeyValueAsync(nextLine.content, cursor, followDepth, options)
+        yield* decodeKeyValueAsync(nextLine.content, cursor, followDepth, options, nextLine.lineNumber)
       }
       else {
         break

--- a/packages/toon/src/decode/validation.ts
+++ b/packages/toon/src/decode/validation.ts
@@ -26,7 +26,7 @@ export function validateNoExtraListItems(
   expectedCount: number,
 ): void {
   if (nextLine?.depth === itemDepth && nextLine.content.startsWith(LIST_ITEM_PREFIX)) {
-    throw new RangeError(`Expected ${expectedCount} list array items, but found more`)
+    throw new RangeError(`Expected ${expectedCount} list array items, but found more (line ${nextLine.lineNumber})`)
   }
 }
 
@@ -43,7 +43,7 @@ export function validateNoExtraTabularRows(
     && !nextLine.content.startsWith(LIST_ITEM_PREFIX)
     && isDataRow(nextLine.content, header.delimiter)
   ) {
-    throw new RangeError(`Expected ${header.length} tabular rows, but found more`)
+    throw new RangeError(`Expected ${header.length} tabular rows, but found more (line ${nextLine.lineNumber})`)
   }
 }
 

--- a/packages/toon/test/decode-errors.test.ts
+++ b/packages/toon/test/decode-errors.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { decode } from '../src/index'
+
+describe('decode error context', () => {
+  describe('line numbers in errors', () => {
+    it('includes line number for missing colon after key', () => {
+      // Line 1 is valid, line 2 has no colon
+      const toon = 'name: Alice\nbadkey'
+      expect(() => decode(toon)).toThrow(/line 2/)
+    })
+
+    it('includes line number for unterminated quoted key', () => {
+      const toon = 'name: Alice\n"unterminated: value'
+      expect(() => decode(toon)).toThrow(/line 2/)
+    })
+
+    it('includes line number for key parse error in nested object', () => {
+      // Line 3 has a key without a colon
+      const toon = 'user:\n  name: Alice\n  badkey'
+      expect(() => decode(toon)).toThrow(/line 3/)
+    })
+
+    it('includes line number for extra list items in strict mode', () => {
+      const toon = 'items[1]:\n  - first\n  - extra'
+      expect(() => decode(toon, { strict: true })).toThrow(/line 3/)
+    })
+
+    it('includes line number for extra tabular rows in strict mode', () => {
+      const toon = 'items[1]{name,age}:\n  Alice,30\n  Bob,25'
+      expect(() => decode(toon, { strict: true })).toThrow(/line 3/)
+    })
+
+    it('valid decode still works after changes', () => {
+      const toon = 'name: Alice\nage: 30\nrole: admin'
+      const result = decode(toon)
+      expect(result).toEqual({ name: 'Alice', age: 30, role: 'admin' })
+    })
+
+    it('nested structures decode correctly', () => {
+      const toon = 'user:\n  name: Alice\n  profile:\n    bio: hello'
+      const result = decode(toon)
+      expect(result).toEqual({ user: { name: 'Alice', profile: { bio: 'hello' } } })
+    })
+
+    it('arrays decode correctly', () => {
+      const toon = 'items[3]:\n  - name: a\n  - name: b\n  - name: c'
+      const result = decode(toon)
+      expect(result).toEqual({ items: [{ name: 'a' }, { name: 'b' }, { name: 'c' }] })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds source line numbers to decode error messages. When TOON decode fails (malformed input, mismatched counts, invalid syntax), the error now tells you which line caused the problem.

## Why this matters

Debugging LLM-generated TOON output is a known pain point. Users get errors like "Missing colon after key" with no indication of where in the input the problem is. This is especially frustrating with large inputs where the error could be on any of dozens of lines.

The line number information was already tracked internally via `ParsedLine.lineNumber` - this change surfaces it in the error messages where users can see it.

Related: [Discussion #250](https://github.com/toon-format/toon/discussions/250) ("How to make AI understand TOON format?"), [spec#19](https://github.com/toon-format/spec/issues/19) (LLM decode reliability).

## Before / After

![error context demo](https://files.catbox.moe/krurr4.gif)

Before:
```
SyntaxError: Missing colon after key
```

After:
```
SyntaxError: Missing colon after key (line 2)
```

## Changes

- `packages/toon/src/decode/decoders.ts`: threaded `lineNumber` parameter through `decodeKeyValueSync`/`decodeKeyValueAsync`, wrapped `parseKeyToken` calls with try/catch to add line context, added `addLineContext` helper, added line numbers to list item format errors
- `packages/toon/src/decode/validation.ts`: added line numbers to extra list item and extra tabular row validation errors
- `packages/toon/test/decode-errors.test.ts`: 8 tests verifying line numbers appear in errors and that valid decode still works

## Testing

All 474 tests pass (8 new + 466 existing). Lint, build, and type checks clean.

This contribution was developed with AI assistance (Claude Code).