### PR TITLE
docs: add toon-zig to community implementations

### DIFF
--- a/docs/ecosystem/implementations.md
+++ b/docs/ecosystem/implementations.md
@@ -45,10 +45,11 @@ Community members have created implementations in additional languages:
 | **OCaml** | [ocaml-toon](https://github.com/davesnx/ocaml-toon) | [@davesnx](https://github.com/davesnx) |
 | **Perl** | [Data::TOON](https://github.com/ytnobody/p5-Data-TOON) | [@ytnobody](https://github.com/ytnobody) |
 | **PHP** | [toon-php](https://github.com/HelgeSverre/toon-php) | [@HelgeSverre](https://github.com/HelgeSverre) |
+| **Python** (Rust backend) | [toons](https://github.com/alesanfra/toons) | [@alesanfra](https://github.com/alesanfra) |
 | **R** | [toon](https://github.com/laresbernardo/toon) | [@laresbernardo](https://github.com/laresbernardo) |
 | **Ruby** | [toon-ruby](https://github.com/andrepcg/toon-ruby) | [@andrepcg](https://github.com/andrepcg) |
 | **Scala** | [toon4s](https://github.com/vim89/toon4s) | [@vim89](https://github.com/vim89) |
-| **Python** (Rust backend) | [toons](https://github.com/alesanfra/toons) | [@alesanfra](https://github.com/alesanfra) |
+| **Zig** | [toon-zig](https://github.com/LatentEvals/toon-zig) | [@montanaflynn](https://github.com/montanaflynn) |
 
 ## Contributing an Implementation
 


### PR DESCRIPTION
Adds [toon-zig](https://github.com/LatentEvals/toon-zig), a Zig implementation of TOON v3.0.

- Passes all 358 official conformance fixtures (encode + decode)
- Implements v1.5 features (key folding with `flattenDepth`, path expansion with deep-merge + conflict detection)
- Targets Zig 0.15.2; no external dependencies
- Arena-allocated decode output

Also moves the existing **Python** (Rust backend) row into its alphabetical position.