### PR TITLE
docs: add go-toon to community implementations

### DIFF
--- a/docs/ecosystem/implementations.md
+++ b/docs/ecosystem/implementations.md
@@ -38,6 +38,7 @@ Community members have created implementations in additional languages:
 | **Elixir** | [toon_ex](https://github.com/kentaro/toon_ex) | [@kentaro](https://github.com/kentaro) |
 | **Gleam** | [toon_codec](https://github.com/axelbellec/toon_codec) | [@axelbellec](https://github.com/axelbellec) |
 | **Go** | [gotoon](https://github.com/alpkeskin/gotoon) | [@alpkeskin](https://github.com/alpkeskin) |
+| **Go** | [go-toon](https://github.com/OTumanov/go-toon) | [@OTumanov](https://github.com/OTumanov) |
 | **Java** | [json-io](https://github.com/jdereg/json-io) | [@jdereg](https://github.com/jdereg) |
 | **Kotlin** | [ktoon](https://github.com/lukelast/ktoon)| [@lukelast](https://github.com/lukelast) |
 | **Laravel Framework** | [laravel-toon](https://github.com/mischasigtermans/laravel-toon) | [@mischasigtermans](https://github.com/mischasigtermans) |


### PR DESCRIPTION
## Summary
- add `go-toon` to the Go entries in the Community Implementations table
- include maintainer profile link for discoverability

## Context
`go-toon` now has public release/versioning, CI workflows, spec fixture integration tracking, and bilingual docs. This PR only updates ecosystem listing visibility.

## Validation
- docs-only change
- table formatting preserved

Made with [Cursor](https://cursor.com)