### PR TITLE
fix: encoder silent row drop, negative/non-decimal array lengths, trailing delimiter, colon re-search

### DIFF
--- a/packages/toon/src/decode/decoders.ts
+++ b/packages/toon/src/decode/decoders.ts
@@ -194,9 +194,10 @@ function* decodeKeyValueSync(
   }
 
   // Regular key-value pair
-  const { key, isQuoted } = withLine(line, () => parseKeyToken(content, 0))
-  const colonIndex = content.indexOf(COLON, key.length)
-  const rest = colonIndex >= 0 ? content.slice(colonIndex + 1).trim() : ''
+  // Use `end` from parseKeyToken directly — it already points to the character
+  // after the colon separator, avoiding a fragile secondary indexOf search.
+  const { key, end, isQuoted } = withLine(line, () => parseKeyToken(content, 0))
+  const rest = content.slice(end).trim()
 
   yield isQuoted ? { type: 'key', key, wasQuoted: true } : { type: 'key', key }
 
@@ -616,9 +617,10 @@ async function* decodeKeyValueAsync(
   }
 
   // Regular key-value pair
-  const { key, isQuoted } = withLine(line, () => parseKeyToken(content, 0))
-  const colonIndex = content.indexOf(COLON, key.length)
-  const rest = colonIndex >= 0 ? content.slice(colonIndex + 1).trim() : ''
+  // Use `end` from parseKeyToken directly — it already points to the character
+  // after the colon separator, avoiding a fragile secondary indexOf search.
+  const { key, end, isQuoted } = withLine(line, () => parseKeyToken(content, 0))
+  const rest = content.slice(end).trim()
 
   yield isQuoted ? { type: 'key', key, wasQuoted: true } : { type: 'key', key }
 

--- a/packages/toon/src/decode/parser.ts
+++ b/packages/toon/src/decode/parser.ts
@@ -136,8 +136,14 @@ export function parseBracketSegment(
     content = content.slice(0, -1)
   }
 
+  // Reject non-decimal-integer strings: hex (0x…), floats (3.7), leading
+  // junk, etc.  parseInt is too permissive — it accepts all of these.
+  if (!/^-?\d+$/.test(content)) {
+    throw new TypeError(`Invalid array length: ${seg}`)
+  }
+
   const length = Number.parseInt(content, 10)
-  if (Number.isNaN(length)) {
+  if (Number.isNaN(length) || length < 0) {
     throw new TypeError(`Invalid array length: ${seg}`)
   }
 
@@ -191,8 +197,10 @@ export function parseDelimitedValues(input: string, delimiter: Delimiter): strin
     i++
   }
 
-  // Add last value
-  if (valueBuffer || values.length > 0) {
+  // Add last value only when there is actual content or a non-trailing
+  // delimiter was seen.  A trailing delimiter (e.g. "a,b,") must not produce
+  // a spurious empty final element.
+  if (valueBuffer.trim() || values.length === 0) {
     values.push(valueBuffer.trim())
   }
 

--- a/packages/toon/src/encode/encoders.ts
+++ b/packages/toon/src/encode/encoders.ts
@@ -183,6 +183,11 @@ export function* encodeArrayOfArraysAsListItemsLines(
       const arrayLine = encodeInlineArrayLine(arr, options.delimiter)
       yield indentedListItem(depth + 1, arrayLine, options.indent)
     }
+    else {
+      // Non-primitive sub-arrays fall back to the mixed/expanded path so no
+      // rows are silently dropped from the declared header count.
+      yield* encodeMixedArrayAsListItemsLines(undefined, arr, depth + 1, options)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Five bugs found via code review of the encoder and decoder, fixed with passing tests (466 tests pass).

---

### Bug 1 — Encoder data loss: non-primitive sub-arrays silently dropped (HIGH)

`encodeArrayOfArraysAsListItemsLines` in `encoders.ts` only emitted list items for sub-arrays that pass `isArrayOfPrimitives`. Sub-arrays containing objects or nested arrays were skipped silently. The header declared `[N]` rows but fewer were emitted, producing structurally invalid TOON that then failed on decode with a confusing count mismatch.

**Fix:** added an `else` branch that falls back to `encodeMixedArrayAsListItemsLines` for non-primitive sub-arrays.

---

### Bug 2 — Negative array lengths accepted (MEDIUM)

`parseBracketSegment` in `parser.ts` checked only `Number.isNaN(length)`. `Number.parseInt("-5", 10)` returns `-5`, not `NaN`, so negative lengths passed through. The decoder looped `while (rowCount < -5)`, consuming zero rows, and `assertExpectedCount(0, -5, ...)` produced a confusing error.

**Fix:** added `length < 0` to the rejection condition.

---

### Bug 3 — Hex and float array lengths silently accepted (MEDIUM)

`parseInt("0x10")` → `16`, `parseInt("3.7")` → `3`. Neither is a valid TOON array length but both passed the `isNaN` check.

**Fix:** added a `/^-?\d+$/` pre-check before `parseInt` to require a clean decimal integer string.

---

### Bug 4 — Trailing delimiter produces spurious empty value (MEDIUM)

`parseDelimitedValues("a,b,", ",")` returned `["a", "b", ""]` instead of `["a", "b"]`. After the loop, the condition `if (valueBuffer || values.length > 0)` pushed an empty `valueBuffer` because `values.length > 0` was true. In strict mode this caused a spurious field-count assertion failure; in non-strict mode it silently added an extra empty field.

**Fix:** changed the post-loop condition to `if (valueBuffer.trim() || values.length === 0)`.

---

### Bug 5 — Colon position re-derived instead of using `parseKeyToken`'s `end` (LOW-MEDIUM)

`decodeKeyValueSync` and `decodeKeyValueAsync` both discarded `end` from `parseKeyToken` and re-searched for the colon via `content.indexOf(COLON, key.length)`. This works today because all current escape sequences expand length, so `key.length` never overshoots the separator. It will silently break if a future escape sequence maps a multi-character source to a shorter decoded key.

**Fix:** destructure `end` from `parseKeyToken` and use `content.slice(end).trim()` in both paths.

---

## Test plan

- `pnpm --filter @toon-format/toon test` — 466 passed, 0 failed
- All existing tests pass without modification
- Note: cases 1–4 are not covered by existing tests — conformance fixtures for these edge cases would be a worthwhile addition