### PR TITLE
fix(decode): prevent false array header detection for unquoted keys c…

### DIFF
--- a/packages/toon/package.json
+++ b/packages/toon/package.json
@@ -38,6 +38,6 @@
     "test": "vitest"
   },
   "devDependencies": {
-    "@toon-format/spec": "^3.3.0"
+    "@toon-format/spec": "^3.3.2"
   }
 }

--- a/packages/toon/src/decode/parser.ts
+++ b/packages/toon/src/decode/parser.ts
@@ -41,6 +41,12 @@ export function parseArrayHeaderLine(
     return
   }
 
+  // A header key can't contain an unquoted colon, so this is a key-value line
+  const firstColonIndex = findUnquotedChar(content, COLON)
+  if (firstColonIndex !== -1 && firstColonIndex < bracketStart) {
+    return
+  }
+
   const bracketEnd = findUnquotedChar(content, CLOSE_BRACKET, bracketStart)
   if (bracketEnd === -1) {
     return

--- a/packages/toon/test/decodeStream.test.ts
+++ b/packages/toon/test/decodeStream.test.ts
@@ -236,6 +236,19 @@ describe('streaming decode', () => {
       expect(events).toEqual(Array.from(decodeStreamSync(lines)))
     })
 
+    it('keeps an unquoted bracket-colon scalar whole, matching decodeStreamSync', async () => {
+      const lines = ['key: foo [2]: bar']
+      const events = await collect(decodeStream(asyncLines(lines)))
+
+      expect(events).toEqual([
+        { type: 'startObject' },
+        { type: 'key', key: 'key' },
+        { type: 'primitive', value: 'foo [2]: bar' },
+        { type: 'endObject' },
+      ])
+      expect(events).toEqual(Array.from(decodeStreamSync(lines)))
+    })
+
     it('keeps a colon-bearing value such as a URL intact', async () => {
       const lines = ['a: http://x']
       const events = await collect(decodeStream(asyncLines(lines)))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
   packages/toon:
     devDependencies:
       '@toon-format/spec':
-        specifier: ^3.3.0
-        version: 3.3.0
+        specifier: ^3.3.2
+        version: 3.3.2
 
 packages:
 
@@ -1187,8 +1187,8 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
-  '@toon-format/spec@3.3.0':
-    resolution: {integrity: sha512-uRXoLvQU8ae79hG0/0zkjI2OIC3ULWyiDVuq3gLlh6uNduEJhAUHKx00KkIwZXnVefshk1uoSpRzMtc05mE0UQ==}
+  '@toon-format/spec@3.3.2':
+    resolution: {integrity: sha512-J2TaK9EQNPW5Hp9GhBavS3u7hE2AD/AqhV7UFYQ5quOnBgEAkUMJC6BwYxVyTRT4yy0rDQGyqK7tmMbwTZuStA==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -4569,7 +4569,7 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.5
 
-  '@toon-format/spec@3.3.0': {}
+  '@toon-format/spec@3.3.2': {}
 
   '@tybys/wasm-util@0.10.3':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ minimumReleaseAgeExclude:
   - '@ai-sdk/xai@3.0.108'
   - ai@6.0.228
   - tsdown@0.22.8
+  - '@toon-format/spec@3.3.2'
 
 shellEmulator: true
 trustPolicy: no-downgrade


### PR DESCRIPTION
## Linked Issue 
 
<!-- Reference the related issue. Example: Closes #123 --> 
 
Closes #324
 
## Description 
 
This PR fixes a bug in the decoder where standard key-value pairs were mistakenly parsed as array headers. 

Previously, if the parser encountered an unquoted key or value string containing both brackets and colons (e.g., `display: "(Hello) [World] this (is:test)"`), it would find the first `[` and assume it was parsing an array header. When it subsequently found the `:` later in the string, it would throw a `SyntaxError: Unexpected content ... between bracket segment and colon`. 

This fix updates `parseArrayHeaderLine` to check if a colon (`:`) appears *before* the first bracket (`[`). If it does, the parser correctly identifies it as a key-value separator and aborts the array header parsing.

To replicate:

```ts
import { encode, decode } from './src'

const jsonSource = {
  message: "Hello [world] this is a test:"
}

const payload = encode(jsonSource)
console.log("Encoded TOON payload:")
console.log(payload)

console.log("\nDecoded object:")
console.log(decode(payload))
```

returns following result

```
❯ bun ./repro.ts  
Encoded TOON payload:
message: "Hello [world] this is a test:"

Decoded object:
12 |   /** Raw source line (including indentation) where the error was detected, if known. */
13 |   readonly source?: string
14 | 
15 |   constructor(message: string, context?: { line?: number, source?: string, cause?: unknown }) {
16 |     const prefix = context?.line !== undefined ? `Line ${context.line}: ` : ''
17 |     super(prefix + message, context?.cause !== undefined ? { cause: context.cause } : undefined)
     ^
ToonDecodeError: Line 1: Unexpected content "this is a test" between bracket segment and colon
   line: 1,
 source: "message: \"Hello [world] this is a test:\"",

      at <parse> ()
      at new ToonDecodeError (/Users/rayriffy/Git/toon/packages/toon/src/decode/errors.ts:17:5)
      at withLine (/Users/rayriffy/Git/toon/packages/toon/src/decode/errors.ts:39:17)
      at decodeKeyValueSync (/Users/rayriffy/Git/toon/packages/toon/src/decode/decoders.ts:368:14)
      at decodeStreamSync (/Users/rayriffy/Git/toon/packages/toon/src/decode/decoders.ts:299:5)
      at buildValueFromEvents (/Users/rayriffy/Git/toon/packages/toon/src/decode/event-builder.ts:60:9)
      at decodeFromLines (/Users/rayriffy/Git/toon/packages/toon/src/index.ts:146:24)

79 |   const gapStart = Math.max(bracketEnd + 1, braceEnd)
80 |   const gapBeforeColon = content.slice(gapStart, colonIndex)
81 |   if (gapBeforeColon !== '') {
82 |     if (strict) {
83 |       const trimmedGap = gapBeforeColon.trim()
84 |       throw new SyntaxError(trimmedGap === ''
                     ^
SyntaxError: Unexpected content "this is a test" between bracket segment and colon
      at parseArrayHeaderLine (/Users/rayriffy/Git/toon/packages/toon/src/decode/parser.ts:84:17)
      at withLine (/Users/rayriffy/Git/toon/packages/toon/src/decode/errors.ts:33:12)
      at decodeKeyValueSync (/Users/rayriffy/Git/toon/packages/toon/src/decode/decoders.ts:217:23)
      at decodeStreamSync (/Users/rayriffy/Git/toon/packages/toon/src/decode/decoders.ts:179:10)
      at buildValueFromEvents (/Users/rayriffy/Git/toon/packages/toon/src/decode/event-builder.ts:22:14)
      at decodeFromLines (/Users/rayriffy/Git/toon/packages/toon/src/index.ts:146:24)
      at /Users/rayriffy/Git/toon/packages/toon/repro.ts:12:13

Bun v1.3.14 (macOS arm64)
```

following the fix

```
❯ bun ./repro.ts
Encoded TOON payload:
message: "Hello [world] this is a test:"

Decoded object:
{
  message: "Hello [world] this is a test:",
}
```
 
## Type of Change 
 
<!-- Mark the relevant option with an [x] --> 
 
- [x] Bug fix (non-breaking change that fixes an issue) 
- [ ] New feature (non-breaking change that adds functionality) 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 
- [ ] Documentation update 
- [ ] Refactoring (no functional changes) 
- [ ] Performance improvement 
- [ ] Test coverage improvement 
 
## Changes Made 
 
<!-- List the main changes in this PR --> 
 
- Added a check in `parseArrayHeaderLine` (`packages/toon/src/decode/parser.ts`) to ensure array header parsing is aborted if a key-value separator (`:`) appears before the first bracket (`[`).
 
## SPEC Compliance 
 
<!-- If this PR relates to the TOON spec, indicate which sections are affected --> 
 
- [x] This PR implements/fixes spec compliance 
- [ ] Spec section(s) affected: Key-Value Pair Parsing
- [ ] Spec version: 3.3
 
## Testing 
 
<!-- Describe the tests you added or ran --> 
 
- [x] All existing tests pass 
- [ ] Added new tests for changes 
- [x] Tests cover edge cases and spec compliance 
 
## Pre-submission Checklist 
 
<!-- Verify before submitting --> 
 
- [x] My code follows the project's coding standards 
- [x] I have run code formatting/linting tools 
- [x] I have added tests that prove my fix/feature works 
- [x] New and existing tests pass locally 
- [ ] I have updated documentation if needed 
- [x] I have reviewed the `https://github.com/toon-format/spec` for relevant sections 
 
## Breaking Changes 
 
<!-- If this is a breaking change, describe the migration path for users --> 
 
- [x] No breaking changes 
- [ ] Breaking changes (describe migration path below) 
 
<!-- Migration path: --> 
 
## Additional Context 
 
This issue was specifically encountered when attempting to parse TOON documents with titles containing translated bracket tags and source parentheses (e.g., doujinshi/gallery metadata).