### PR TITLE
fix: harden encode and decode against prototype pollution

### DIFF
--- a/packages/toon/src/decode/event-builder.ts
+++ b/packages/toon/src/decode/event-builder.ts
@@ -63,7 +63,7 @@ function applyEvent(state: BuildState, event: JsonStreamEvent): void {
             throw new Error('Object startObject event without preceding key')
           }
 
-          parent.obj[parent.currentKey] = obj
+          setObjectProperty(parent.obj, parent.currentKey, obj)
           parent.currentKey = undefined
         }
         else if (parent.type === 'array') {
@@ -116,7 +116,7 @@ function applyEvent(state: BuildState, event: JsonStreamEvent): void {
           if (parent.currentKey === undefined) {
             throw new Error('Array startArray event without preceding key')
           }
-          parent.obj[parent.currentKey] = arr
+          setObjectProperty(parent.obj, parent.currentKey, arr)
           parent.currentKey = undefined
         }
         else if (parent.type === 'array') {
@@ -177,7 +177,7 @@ function applyEvent(state: BuildState, event: JsonStreamEvent): void {
           if (parent.currentKey === undefined) {
             throw new Error('Primitive event without preceding key in object')
           }
-          parent.obj[parent.currentKey] = event.value
+          setObjectProperty(parent.obj, parent.currentKey, event.value)
           parent.currentKey = undefined
         }
         else if (parent.type === 'array') {
@@ -200,6 +200,16 @@ function finalizeState(state: BuildState): JsonValue {
   }
 
   return state.root
+}
+
+function setObjectProperty(target: JsonObject, key: string, value: JsonValue): void {
+  // Avoid invoking Object.prototype accessors such as __proto__ while decoding.
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  })
 }
 
 // #endregion

--- a/packages/toon/src/decode/event-builder.ts
+++ b/packages/toon/src/decode/event-builder.ts
@@ -1,4 +1,5 @@
 import type { JsonObject, JsonStreamEvent, JsonValue } from '../types.ts'
+import { setOwnProperty } from '../shared/object-utils.ts'
 import { QUOTED_KEY_MARKER } from './expand.ts'
 
 // #region Build context types
@@ -63,7 +64,7 @@ function applyEvent(state: BuildState, event: JsonStreamEvent): void {
             throw new Error('Object startObject event without preceding key')
           }
 
-          setObjectProperty(parent.obj, parent.currentKey, obj)
+          setOwnProperty(parent.obj, parent.currentKey, obj)
           parent.currentKey = undefined
         }
         else if (parent.type === 'array') {
@@ -116,7 +117,7 @@ function applyEvent(state: BuildState, event: JsonStreamEvent): void {
           if (parent.currentKey === undefined) {
             throw new Error('Array startArray event without preceding key')
           }
-          setObjectProperty(parent.obj, parent.currentKey, arr)
+          setOwnProperty(parent.obj, parent.currentKey, arr)
           parent.currentKey = undefined
         }
         else if (parent.type === 'array') {
@@ -177,7 +178,7 @@ function applyEvent(state: BuildState, event: JsonStreamEvent): void {
           if (parent.currentKey === undefined) {
             throw new Error('Primitive event without preceding key in object')
           }
-          setObjectProperty(parent.obj, parent.currentKey, event.value)
+          setOwnProperty(parent.obj, parent.currentKey, event.value)
           parent.currentKey = undefined
         }
         else if (parent.type === 'array') {
@@ -200,16 +201,6 @@ function finalizeState(state: BuildState): JsonValue {
   }
 
   return state.root
-}
-
-function setObjectProperty(target: JsonObject, key: string, value: JsonValue): void {
-  // Avoid invoking Object.prototype accessors such as __proto__ while decoding.
-  Object.defineProperty(target, key, {
-    value,
-    enumerable: true,
-    writable: true,
-    configurable: true,
-  })
 }
 
 // #endregion

--- a/packages/toon/src/decode/expand.ts
+++ b/packages/toon/src/decode/expand.ts
@@ -73,7 +73,7 @@ export function expandPathsSafe(value: JsonValue, strict: boolean): JsonValue {
       const expandedValue = expandPathsSafe(keyValue, strict)
 
       // Check for conflicts with already-expanded keys
-      if (key in expandedObject) {
+      if (Object.hasOwn(expandedObject, key)) {
         const conflictingValue = expandedObject[key]!
         // If both are objects, try to merge them
         if (canMerge(conflictingValue, expandedValue)) {
@@ -87,12 +87,12 @@ export function expandPathsSafe(value: JsonValue, strict: boolean): JsonValue {
             )
           }
           // Non-strict: overwrite (LWW)
-          expandedObject[key] = expandedValue
+          setOwnProperty(expandedObject, key, expandedValue)
         }
       }
       else {
         // No conflict - insert directly
-        expandedObject[key] = expandedValue
+        setOwnProperty(expandedObject, key, expandedValue)
       }
     }
 
@@ -131,12 +131,12 @@ function insertPathSafe(
   // Walk to the penultimate segment, creating objects as needed
   for (let i = 0; i < segments.length - 1; i++) {
     const currentSegment = segments[i]!
-    const segmentValue = currentNode[currentSegment]
+    const segmentValue = getOwnProperty(currentNode, currentSegment)
 
     if (segmentValue === undefined) {
       // Create new intermediate object
       const newObj: JsonObject = {}
-      currentNode[currentSegment] = newObj
+      setOwnProperty(currentNode, currentSegment, newObj)
       currentNode = newObj
     }
     else if (isJsonObject(segmentValue)) {
@@ -152,18 +152,18 @@ function insertPathSafe(
       }
       // Non-strict: overwrite with new object
       const newObj: JsonObject = {}
-      currentNode[currentSegment] = newObj
+      setOwnProperty(currentNode, currentSegment, newObj)
       currentNode = newObj
     }
   }
 
   // Insert at the final segment
   const lastSeg = segments[segments.length - 1]!
-  const destinationValue = currentNode[lastSeg]
+  const destinationValue = getOwnProperty(currentNode, lastSeg)
 
   if (destinationValue === undefined) {
     // No conflict - insert directly
-    currentNode[lastSeg] = value
+    setOwnProperty(currentNode, lastSeg, value)
   }
   else if (canMerge(destinationValue, value)) {
     // Both are objects - deep merge
@@ -177,7 +177,7 @@ function insertPathSafe(
       )
     }
     // Non-strict: overwrite (LWW)
-    currentNode[lastSeg] = value
+    setOwnProperty(currentNode, lastSeg, value)
   }
 }
 
@@ -201,13 +201,14 @@ function mergeObjects(
   strict: boolean,
 ): void {
   for (const [key, sourceValue] of Object.entries(source)) {
-    const targetValue = target[key]
-
-    if (targetValue === undefined) {
+    if (!Object.hasOwn(target, key)) {
       // Key doesn't exist in target - copy it
-      target[key] = sourceValue
+      setOwnProperty(target, key, sourceValue)
+      continue
     }
-    else if (canMerge(targetValue, sourceValue)) {
+
+    const targetValue = target[key] as JsonValue
+    if (canMerge(targetValue, sourceValue)) {
       // Both are objects - recursively merge
       mergeObjects(targetValue as JsonObject, sourceValue as JsonObject, strict)
     }
@@ -219,9 +220,23 @@ function mergeObjects(
         )
       }
       // Non-strict: overwrite (LWW)
-      target[key] = sourceValue
+      setOwnProperty(target, key, sourceValue)
     }
   }
+}
+
+function getOwnProperty(target: JsonObject, key: string): JsonValue | undefined {
+  return Object.hasOwn(target, key) ? target[key] : undefined
+}
+
+function setOwnProperty(target: JsonObject, key: string, value: JsonValue): void {
+  // Avoid invoking Object.prototype accessors such as __proto__ while expanding paths.
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  })
 }
 
 // #endregion

--- a/packages/toon/src/decode/expand.ts
+++ b/packages/toon/src/decode/expand.ts
@@ -1,6 +1,7 @@
 import type { JsonObject, JsonValue } from '../types.ts'
 import { DOT } from '../constants.ts'
 import { isJsonObject } from '../encode/normalize.ts'
+import { getOwnProperty, setOwnProperty } from '../shared/object-utils.ts'
 import { isIdentifierSegment } from '../shared/validation.ts'
 
 // #region Path expansion (safe)
@@ -223,20 +224,6 @@ function mergeObjects(
       setOwnProperty(target, key, sourceValue)
     }
   }
-}
-
-function getOwnProperty(target: JsonObject, key: string): JsonValue | undefined {
-  return Object.hasOwn(target, key) ? target[key] : undefined
-}
-
-function setOwnProperty(target: JsonObject, key: string, value: JsonValue): void {
-  // Avoid invoking Object.prototype accessors such as __proto__ while expanding paths.
-  Object.defineProperty(target, key, {
-    value,
-    enumerable: true,
-    writable: true,
-    configurable: true,
-  })
 }
 
 // #endregion

--- a/packages/toon/src/encode/encoders.ts
+++ b/packages/toon/src/encode/encoders.ts
@@ -241,7 +241,7 @@ export function isTabularArray(
 
     // Check that all header keys exist in the row and all values are primitives
     for (const key of header) {
-      if (!(key in row)) {
+      if (!Object.hasOwn(row, key)) {
         return false
       }
       if (!isJsonPrimitive(row[key])) {

--- a/packages/toon/src/encode/normalize.ts
+++ b/packages/toon/src/encode/normalize.ts
@@ -1,4 +1,5 @@
 import type { JsonArray, JsonObject, JsonPrimitive, JsonValue } from '../types.ts'
+import { setOwnProperty } from '../shared/object-utils.ts'
 
 // #region Normalization (unknown → JsonValue)
 
@@ -85,16 +86,6 @@ export function normalizeValue(value: unknown): JsonValue {
 
   // Fallback: function, symbol, undefined, or other → null
   return null
-}
-
-export function setOwnProperty(target: JsonObject, key: string, value: JsonValue): void {
-  // Avoid invoking Object.prototype accessors such as __proto__ while normalizing.
-  Object.defineProperty(target, key, {
-    value,
-    enumerable: true,
-    writable: true,
-    configurable: true,
-  })
 }
 
 // #endregion

--- a/packages/toon/src/encode/normalize.ts
+++ b/packages/toon/src/encode/normalize.ts
@@ -76,7 +76,7 @@ export function normalizeValue(value: unknown): JsonValue {
 
     for (const key in value) {
       if (Object.hasOwn(value, key)) {
-        encodedValues[key] = normalizeValue(value[key])
+        setOwnProperty(encodedValues, key, normalizeValue(value[key]))
       }
     }
 
@@ -85,6 +85,16 @@ export function normalizeValue(value: unknown): JsonValue {
 
   // Fallback: function, symbol, undefined, or other → null
   return null
+}
+
+export function setOwnProperty(target: JsonObject, key: string, value: JsonValue): void {
+  // Avoid invoking Object.prototype accessors such as __proto__ while normalizing.
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  })
 }
 
 // #endregion

--- a/packages/toon/src/encode/replacer.ts
+++ b/packages/toon/src/encode/replacer.ts
@@ -1,5 +1,5 @@
 import type { EncodeReplacer, JsonArray, JsonObject, JsonValue } from '../types.ts'
-import { isJsonArray, isJsonObject, normalizeValue } from './normalize.ts'
+import { isJsonArray, isJsonObject, normalizeValue, setOwnProperty } from './normalize.ts'
 
 /**
  * Applies a replacer function to a `JsonValue` and all its descendants.
@@ -83,7 +83,7 @@ function transformObject(
     const normalizedValue = normalizeValue(replacedValue)
 
     // Recursively transform children of the replaced value
-    result[key] = transformChildren(normalizedValue, replacer, childPath)
+    setOwnProperty(result, key, transformChildren(normalizedValue, replacer, childPath))
   }
 
   return result

--- a/packages/toon/src/encode/replacer.ts
+++ b/packages/toon/src/encode/replacer.ts
@@ -1,5 +1,6 @@
 import type { EncodeReplacer, JsonArray, JsonObject, JsonValue } from '../types.ts'
-import { isJsonArray, isJsonObject, normalizeValue, setOwnProperty } from './normalize.ts'
+import { setOwnProperty } from '../shared/object-utils.ts'
+import { isJsonArray, isJsonObject, normalizeValue } from './normalize.ts'
 
 /**
  * Applies a replacer function to a `JsonValue` and all its descendants.

--- a/packages/toon/src/shared/object-utils.ts
+++ b/packages/toon/src/shared/object-utils.ts
@@ -16,14 +16,20 @@ export function getOwnProperty(target: JsonObject, key: string): JsonValue | und
  *
  * @remarks
  * A plain `target[key] = value` would trigger the `Object.prototype` setter for
- * keys such as `__proto__`, corrupting the prototype chain instead of storing an
- * own entry. Defining the property pins it as an ordinary own value.
+ * `__proto__`, corrupting the prototype chain instead of storing an own entry.
+ * Defining the property pins it as an ordinary own value; every other key takes
+ * the plain-assignment fast path since `defineProperty` is markedly slower.
  */
 export function setOwnProperty(target: JsonObject, key: string, value: JsonValue): void {
-  Object.defineProperty(target, key, {
-    value,
-    enumerable: true,
-    writable: true,
-    configurable: true,
-  })
+  if (key === '__proto__') {
+    Object.defineProperty(target, key, {
+      value,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    })
+    return
+  }
+
+  target[key] = value
 }

--- a/packages/toon/src/shared/object-utils.ts
+++ b/packages/toon/src/shared/object-utils.ts
@@ -1,0 +1,29 @@
+import type { JsonObject, JsonValue } from '../types.ts'
+
+/**
+ * Reads an own data property, treating inherited and absent keys alike.
+ *
+ * @remarks
+ * Uses {@link Object.hasOwn} so prototype keys such as `__proto__` never
+ * resolve through `Object.prototype`.
+ */
+export function getOwnProperty(target: JsonObject, key: string): JsonValue | undefined {
+  return Object.hasOwn(target, key) ? target[key] : undefined
+}
+
+/**
+ * Assigns an own data property without invoking inherited accessors.
+ *
+ * @remarks
+ * A plain `target[key] = value` would trigger the `Object.prototype` setter for
+ * keys such as `__proto__`, corrupting the prototype chain instead of storing an
+ * own entry. Defining the property pins it as an ordinary own value.
+ */
+export function setOwnProperty(target: JsonObject, key: string, value: JsonValue): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  })
+}

--- a/packages/toon/src/shared/object-utils.ts
+++ b/packages/toon/src/shared/object-utils.ts
@@ -4,8 +4,7 @@ import type { JsonObject, JsonValue } from '../types.ts'
  * Reads an own data property, treating inherited and absent keys alike.
  *
  * @remarks
- * Uses {@link Object.hasOwn} so prototype keys such as `__proto__` never
- * resolve through `Object.prototype`.
+ * Keys such as `__proto__` must not resolve through the prototype chain.
  */
 export function getOwnProperty(target: JsonObject, key: string): JsonValue | undefined {
   return Object.hasOwn(target, key) ? target[key] : undefined
@@ -15,10 +14,9 @@ export function getOwnProperty(target: JsonObject, key: string): JsonValue | und
  * Assigns an own data property without invoking inherited accessors.
  *
  * @remarks
- * A plain `target[key] = value` would trigger the `Object.prototype` setter for
- * `__proto__`, corrupting the prototype chain instead of storing an own entry.
- * Defining the property pins it as an ordinary own value; every other key takes
- * the plain-assignment fast path since `defineProperty` is markedly slower.
+ * Plain assignment of `__proto__` would hit the `Object.prototype` setter and
+ * corrupt the prototype chain; `defineProperty` avoids that but is markedly
+ * slower, so every other key takes plain assignment.
  */
 export function setOwnProperty(target: JsonObject, key: string, value: JsonValue): void {
   if (key === '__proto__') {

--- a/packages/toon/test/decode-security.test.ts
+++ b/packages/toon/test/decode-security.test.ts
@@ -19,6 +19,16 @@ describe('decode security hardening', () => {
     }
   })
 
+  it.each([
+    ['primitive', '__proto__: true', true],
+    ['array', '__proto__[2]: 1,2', [1, 2]],
+  ])('keeps direct __proto__ %s values as own data properties', (_name, input, expected) => {
+    const decoded = decode(input) as Record<string, any>
+
+    expect(Object.hasOwn(decoded, prototypeKey)).toBe(true)
+    expect(decoded[prototypeKey]).toEqual(expected)
+  })
+
   it('does not follow Object.prototype during dotted path expansion', () => {
     const marker = '__toonExpandedPolluted'
 
@@ -34,5 +44,42 @@ describe('decode security hardening', () => {
     finally {
       delete (Object.prototype as Record<string, unknown>)[marker]
     }
+  })
+
+  it('keeps constructor.prototype expansion within own properties', () => {
+    const marker = '__toonConstructorPolluted'
+
+    try {
+      const decoded = decode(`constructor.prototype.${marker}: true\n`, {
+        expandPaths: 'safe',
+      }) as Record<string, any>
+
+      expect(Object.hasOwn(decoded, 'constructor')).toBe(true)
+      expect(Object.hasOwn(decoded.constructor, 'prototype')).toBe(true)
+      expect(decoded.constructor.prototype[marker]).toBe(true)
+      expect(({} as Record<string, unknown>)[marker]).toBeUndefined()
+    }
+    finally {
+      delete (Object.prototype as Record<string, unknown>)[marker]
+    }
+  })
+
+  it('safely merges an expanded __proto__ path with a direct object', () => {
+    const decoded = decode(`__proto__.first: true\n__proto__:\n  second: true\n`, {
+      expandPaths: 'safe',
+    }) as Record<string, any>
+
+    expect(Object.hasOwn(decoded, prototypeKey)).toBe(true)
+    expect(decoded[prototypeKey]).toEqual({ first: true, second: true })
+  })
+
+  it('safely overwrites a primitive __proto__ conflict in non-strict mode', () => {
+    const decoded = decode(`__proto__: 1\n__proto__.second: true\n`, {
+      expandPaths: 'safe',
+      strict: false,
+    }) as Record<string, any>
+
+    expect(Object.hasOwn(decoded, prototypeKey)).toBe(true)
+    expect(decoded[prototypeKey]).toEqual({ second: true })
   })
 })

--- a/packages/toon/test/decode-security.test.ts
+++ b/packages/toon/test/decode-security.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { decode } from '../src/index'
+
+describe('decode security hardening', () => {
+  const prototypeKey = '__proto__'
+
+  it('keeps direct __proto__ keys as own data properties', () => {
+    const marker = '__toonDirectPolluted'
+
+    try {
+      const decoded = decode(`__proto__:\n  ${marker}: true\n`) as Record<string, any>
+
+      expect(Object.hasOwn(decoded, prototypeKey)).toBe(true)
+      expect(decoded[prototypeKey][marker]).toBe(true)
+      expect(({} as Record<string, unknown>)[marker]).toBeUndefined()
+    }
+    finally {
+      delete (Object.prototype as Record<string, unknown>)[marker]
+    }
+  })
+
+  it('does not follow Object.prototype during dotted path expansion', () => {
+    const marker = '__toonExpandedPolluted'
+
+    try {
+      const decoded = decode(`payload.__proto__.${marker}: true\n`, {
+        expandPaths: 'safe',
+      }) as Record<string, any>
+
+      expect(Object.hasOwn(decoded.payload, prototypeKey)).toBe(true)
+      expect(decoded.payload[prototypeKey][marker]).toBe(true)
+      expect(({} as Record<string, unknown>)[marker]).toBeUndefined()
+    }
+    finally {
+      delete (Object.prototype as Record<string, unknown>)[marker]
+    }
+  })
+})

--- a/packages/toon/test/decodeStream.test.ts
+++ b/packages/toon/test/decodeStream.test.ts
@@ -38,6 +38,21 @@ describe('streaming decode', () => {
       ])
     })
 
+    it('preserves __proto__ keys in events', () => {
+      const lines = ['__proto__:', '  safe: true']
+      const events = Array.from(decodeStreamSync(lines))
+
+      expect(events).toEqual([
+        { type: 'startObject' },
+        { type: 'key', key: '__proto__' },
+        { type: 'startObject' },
+        { type: 'key', key: 'safe' },
+        { type: 'primitive', value: true },
+        { type: 'endObject' },
+        { type: 'endObject' },
+      ])
+    })
+
     it('decodes inline primitive array', () => {
       const input = 'scores[3]: 95, 87, 92'
       const lines = input.split('\n')
@@ -224,6 +239,21 @@ describe('streaming decode', () => {
         { type: 'endObject' },
       ])
       expect(events).toEqual(Array.from(decodeStreamSync(lines)))
+    })
+
+    it('preserves __proto__ keys in events', async () => {
+      const lines = ['__proto__:', '  safe: true']
+      const events = await collect(decodeStream(asyncLines(lines)))
+
+      expect(events).toEqual([
+        { type: 'startObject' },
+        { type: 'key', key: '__proto__' },
+        { type: 'startObject' },
+        { type: 'key', key: 'safe' },
+        { type: 'primitive', value: true },
+        { type: 'endObject' },
+        { type: 'endObject' },
+      ])
     })
 
     it('rejects expandPaths option', async () => {

--- a/packages/toon/test/decodeStream.test.ts
+++ b/packages/toon/test/decodeStream.test.ts
@@ -38,19 +38,14 @@ describe('streaming decode', () => {
       ])
     })
 
-    it('preserves __proto__ keys in events', () => {
+    it('materializes __proto__ as an own property', () => {
+      const prototypeKey = '__proto__'
       const lines = ['__proto__:', '  safe: true']
-      const events = Array.from(decodeStreamSync(lines))
+      const result = buildValueFromEvents(decodeStreamSync(lines)) as Record<string, unknown>
 
-      expect(events).toEqual([
-        { type: 'startObject' },
-        { type: 'key', key: '__proto__' },
-        { type: 'startObject' },
-        { type: 'key', key: 'safe' },
-        { type: 'primitive', value: true },
-        { type: 'endObject' },
-        { type: 'endObject' },
-      ])
+      expect(Object.hasOwn(result, prototypeKey)).toBe(true)
+      expect(result[prototypeKey]).toEqual({ safe: true })
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
     })
 
     it('decodes inline primitive array', () => {
@@ -241,19 +236,15 @@ describe('streaming decode', () => {
       expect(events).toEqual(Array.from(decodeStreamSync(lines)))
     })
 
-    it('preserves __proto__ keys in events', async () => {
+    it('materializes __proto__ as an own property', async () => {
+      const prototypeKey = '__proto__'
       const lines = ['__proto__:', '  safe: true']
       const events = await collect(decodeStream(asyncLines(lines)))
+      const result = await buildValueFromEventsAsync(asyncEvents(events)) as Record<string, unknown>
 
-      expect(events).toEqual([
-        { type: 'startObject' },
-        { type: 'key', key: '__proto__' },
-        { type: 'startObject' },
-        { type: 'key', key: 'safe' },
-        { type: 'primitive', value: true },
-        { type: 'endObject' },
-        { type: 'endObject' },
-      ])
+      expect(Object.hasOwn(result, prototypeKey)).toBe(true)
+      expect(result[prototypeKey]).toEqual({ safe: true })
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
     })
 
     it('rejects expandPaths option', async () => {

--- a/packages/toon/test/encode-security.test.ts
+++ b/packages/toon/test/encode-security.test.ts
@@ -39,4 +39,51 @@ describe('encode security hardening', () => {
       delete (Object.prototype as Record<string, unknown>)[marker]
     }
   })
+
+  it('preserves nested own __proto__ properties introduced by a replacer', () => {
+    const marker = '__toonNestedReplacerPolluted'
+    const replacement = JSON.parse(`{"__proto__":{"${marker}":true},"safe":1}`)
+    const replacer: EncodeReplacer = (key, value) => key === 'payload' ? replacement : value
+
+    try {
+      const decoded = decode(encode({ payload: null }, { replacer })) as Record<string, any>
+
+      expect(Object.hasOwn(decoded.payload, prototypeKey)).toBe(true)
+      expect(decoded.payload[prototypeKey][marker]).toBe(true)
+      expect(decoded.payload.safe).toBe(1)
+      expect(({} as Record<string, unknown>)[marker]).toBeUndefined()
+    }
+    finally {
+      delete (Object.prototype as Record<string, unknown>)[marker]
+    }
+  })
+
+  it('preserves own __proto__ properties through key folding and expansion', () => {
+    const input = JSON.parse('{"__proto__":{"inner":{"folded":true}}}')
+    const encoded = encode(input, { keyFolding: 'safe' })
+    const decoded = decode(encoded, { expandPaths: 'safe' }) as Record<string, any>
+
+    expect(Object.hasOwn(decoded, prototypeKey)).toBe(true)
+    expect(decoded[prototypeKey].inner.folded).toBe(true)
+  })
+
+  it('does not use inherited properties to classify tabular rows', () => {
+    const inheritedKey = '__toonInheritedTabularField'
+    const input = [{ [inheritedKey]: 'user' }, { other: 'kept' }]
+
+    // eslint-disable-next-line no-extend-native -- Simulate a pre-polluted environment.
+    Object.defineProperty(Object.prototype, inheritedKey, {
+      value: 'admin',
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    })
+
+    try {
+      expect(decode(encode(input))).toEqual(input)
+    }
+    finally {
+      delete (Object.prototype as Record<string, unknown>)[inheritedKey]
+    }
+  })
 })

--- a/packages/toon/test/encode-security.test.ts
+++ b/packages/toon/test/encode-security.test.ts
@@ -22,24 +22,6 @@ describe('encode security hardening', () => {
     }
   })
 
-  it('preserves own __proto__ properties when applying a replacer', () => {
-    const marker = '__toonReplacerPolluted'
-    const input = JSON.parse(`{"__proto__":{"${marker}":true},"b":2}`)
-    const identityReplacer: EncodeReplacer = (_key, value) => value
-
-    try {
-      const decoded = decode(encode(input, { replacer: identityReplacer })) as Record<string, any>
-
-      expect(Object.hasOwn(decoded, prototypeKey)).toBe(true)
-      expect(decoded[prototypeKey][marker]).toBe(true)
-      expect(decoded.b).toBe(2)
-      expect(({} as Record<string, unknown>)[marker]).toBeUndefined()
-    }
-    finally {
-      delete (Object.prototype as Record<string, unknown>)[marker]
-    }
-  })
-
   it('preserves nested own __proto__ properties introduced by a replacer', () => {
     const marker = '__toonNestedReplacerPolluted'
     const replacement = JSON.parse(`{"__proto__":{"${marker}":true},"safe":1}`)

--- a/packages/toon/test/encode-security.test.ts
+++ b/packages/toon/test/encode-security.test.ts
@@ -1,0 +1,42 @@
+import type { EncodeReplacer } from '../src/index'
+import { describe, expect, it } from 'vitest'
+import { decode, encode } from '../src/index'
+
+describe('encode security hardening', () => {
+  const prototypeKey = '__proto__'
+
+  it('preserves own __proto__ properties through an encode/decode round trip', () => {
+    const marker = '__toonEncodedPolluted'
+    const input = JSON.parse(`{"__proto__":{"${marker}":true},"b":2}`)
+
+    try {
+      const decoded = decode(encode(input)) as Record<string, any>
+
+      expect(Object.hasOwn(decoded, prototypeKey)).toBe(true)
+      expect(decoded[prototypeKey][marker]).toBe(true)
+      expect(decoded.b).toBe(2)
+      expect(({} as Record<string, unknown>)[marker]).toBeUndefined()
+    }
+    finally {
+      delete (Object.prototype as Record<string, unknown>)[marker]
+    }
+  })
+
+  it('preserves own __proto__ properties when applying a replacer', () => {
+    const marker = '__toonReplacerPolluted'
+    const input = JSON.parse(`{"__proto__":{"${marker}":true},"b":2}`)
+    const identityReplacer: EncodeReplacer = (_key, value) => value
+
+    try {
+      const decoded = decode(encode(input, { replacer: identityReplacer })) as Record<string, any>
+
+      expect(Object.hasOwn(decoded, prototypeKey)).toBe(true)
+      expect(decoded[prototypeKey][marker]).toBe(true)
+      expect(decoded.b).toBe(2)
+      expect(({} as Record<string, unknown>)[marker]).toBeUndefined()
+    }
+    finally {
+      delete (Object.prototype as Record<string, unknown>)[marker]
+    }
+  })
+})

--- a/packages/toon/test/encode-security.test.ts
+++ b/packages/toon/test/encode-security.test.ts
@@ -53,7 +53,7 @@ describe('encode security hardening', () => {
     const inheritedKey = '__toonInheritedTabularField'
     const input = [{ [inheritedKey]: 'user' }, { other: 'kept' }]
 
-    // eslint-disable-next-line no-extend-native -- Simulate a pre-polluted environment.
+    // eslint-disable-next-line no-extend-native -- Simulate a pre-polluted environment
     Object.defineProperty(Object.prototype, inheritedKey, {
       value: 'admin',
       enumerable: true,


### PR DESCRIPTION
## Summary
- materialize decoded and normalized object keys with own data-property writes so `__proto__` does not invoke prototype accessors
- use own-property checks during safe dotted-path expansion, so inherited names do not create false conflicts or redirect traversal onto `Object.prototype`
- preserve own `__proto__` properties through encoder normalization and replacer traversal
- require tabular rows to own every header field, preventing inherited properties from fabricating columns or replacing row data
- add adversarial regression coverage across `encode`, `decode`, `decodeStreamSync`, and `decodeStream`, including constructor/prototype paths, merge conflicts, replacers, folding, and pre-polluted prototypes

## Validation
- `nvm exec 24 corepack pnpm run lint`
- `nvm exec 24 corepack pnpm run test:types`
- `nvm exec 24 corepack pnpm run test` (614 tests passed)
- `nvm exec 24 corepack pnpm run build`
- `autoreview --mode local --prompt-file /tmp/pr316-adversarial-review.md --codex-bin /Applications/ChatGPT.app/Contents/Resources/codex`

Autoreview result: clean, no accepted/actionable findings reported.
