### PR TITLE
fix: limit nesting depth for encode and decode

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -159,6 +159,7 @@ When using the `--stats` flag with encode, the CLI builds the full TOON string o
 | `--no-strict` | Skip decode validation (array counts, indentation, header delimiter); last-write-wins on duplicate keys |
 | `--keyFolding <mode>` | Key folding mode: `off`, `safe` (default: `off`) |
 | `--flattenDepth <number>` | Maximum segments to fold (default: `Infinity`) – requires `--keyFolding safe` |
+| `--maxDepth <number>` | Maximum structural nesting depth for encode/decode (default: `1000`; use `Infinity` to disable) |
 | `--expandPaths <mode>` | Path expansion mode: `off`, `safe` (default: `off`) |
 | `--verbose` | Show full stack traces and cause chains for errors (default: `false`) |
 
@@ -232,6 +233,17 @@ toon data.toon --no-strict -o output.json
 ```
 
 With `--no-strict`, the decoder stops enforcing array count matches, indentation multiples, and header delimiter mismatches. Duplicate sibling keys no longer throw – the last value wins. Malformed array headers fall back to plain `key: value` lines instead of erroring.
+
+### Depth Limits
+
+Encode and decode reject documents deeper than `--maxDepth` (default: `1000`) to avoid stack exhaustion on hostile or accidental deeply nested inputs:
+
+```bash
+toon data.json --maxDepth 200 -o output.toon
+toon data.toon --decode --maxDepth 200 -o output.json
+```
+
+Pass `--maxDepth Infinity` only for trusted inputs that intentionally exceed the default nesting limit.
 
 ### Decode Error Output
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -37,7 +37,8 @@ const toon = encode(data, {
   indent: 2,
   delimiter: ',',
   keyFolding: 'off',
-  flattenDepth: Infinity
+  flattenDepth: Infinity,
+  maxDepth: 1000
 })
 ```
 
@@ -286,7 +287,8 @@ import { decode } from '@toon-format/toon'
 const data = decode(toon, {
   indent: 2,
   strict: true,
-  expandPaths: 'off'
+  expandPaths: 'off',
+  maxDepth: 1000
 })
 ```
 
@@ -552,6 +554,7 @@ Configuration for [`encode()`](#encode-input-options) and [`encodeLines()`](#enc
 | `delimiter` | `','` \| `'\t'` \| `'\|'` | `','` | Delimiter for array values and tabular rows |
 | `keyFolding` | `'off'` \| `'safe'` | `'off'` | Enable key folding to collapse single-key wrapper chains into dotted paths |
 | `flattenDepth` | `number` | `Infinity` | Maximum number of segments to fold when `keyFolding` is enabled (values 0-1 have no practical effect) |
+| `maxDepth` | `number` | `1000` | Maximum structural nesting depth to encode; use `Infinity` to disable |
 | `replacer` | `EncodeReplacer` | `undefined` | Optional hook to transform or omit values before encoding (see [Replacer Function](#replacer-function)) |
 
 **Delimiter options:**
@@ -583,6 +586,7 @@ Configuration for [`decode()`](#decode-input-options) and [`decodeFromLines()`](
 | `indent` | `number` | `2` | Expected number of spaces per indentation level |
 | `strict` | `boolean` | `true` | Enable strict validation (array counts, indentation, delimiter consistency) |
 | `expandPaths` | `'off'` \| `'safe'` | `'off'` | Enable path expansion to reconstruct dotted keys into nested objects (pairs with `keyFolding: 'safe'`) |
+| `maxDepth` | `number` | `1000` | Maximum structural nesting depth to decode; use `Infinity` to disable |
 
 By default (`strict: true`), the decoder validates input strictly:
 
@@ -592,6 +596,7 @@ By default (`strict: true`), the decoder validates input strictly:
 - **Header delimiter mismatch**: Throws when the bracket-declared delimiter differs from the field-list delimiter (§14.2)
 - **Indentation errors**: Throws when leading spaces aren't exact multiples of `indent`
 - **Header structure**: Throws on leading-zero or non-integer array lengths and on intervening content between bracket/fields/colon
+- **Maximum nesting depth**: Throws when indentation or safe path expansion exceeds `maxDepth` (default `1000`)
 - **Duplicate sibling keys**: Throws when an object has two children with the same key (§14.4)
 - **Path-expansion conflicts**: When `expandPaths: 'safe'` is set, throws on overlapping dotted paths that would collide
 
@@ -609,6 +614,7 @@ Configuration for [`decodeStreamSync()`](#decodestreamsync-lines-options) and [`
 |--------|------|---------|-------------|
 | `indent` | `number` | `2` | Expected number of spaces per indentation level |
 | `strict` | `boolean` | `true` | Enable strict validation (array counts, indentation, delimiter consistency) |
+| `maxDepth` | `number` | `1000` | Maximum structural nesting depth to decode; use `Infinity` to disable |
 
 ::: warning Path Expansion Not Supported
 Path expansion requires building the full value tree, which is incompatible with event streaming. Use [`decodeFromLines()`](#decodefromlines-lines-options) if you need path expansion.
@@ -642,6 +648,7 @@ DELIMITERS // { comma: ',', tab: '\t', pipe: '|' }
 | Export | Description |
 |--------|-------------|
 | `DEFAULT_DELIMITER` | The default delimiter character (`,`) used when none is specified |
+| `DEFAULT_MAX_DEPTH` | The default maximum structural nesting depth (`1000`) |
 | `DELIMITERS` | Frozen record mapping delimiter names to their characters |
 | `Delimiter` | Type union of valid delimiter characters: `',' \| '\t' \| '\|'` |
 | `DelimiterKey` | Type union of delimiter names: `'comma' \| 'tab' \| 'pipe'` |

--- a/packages/cli/src/conversion.ts
+++ b/packages/cli/src/conversion.ts
@@ -18,6 +18,7 @@ export async function encodeToToon(config: {
   delimiter: NonNullable<EncodeOptions['delimiter']>
   keyFolding?: NonNullable<EncodeOptions['keyFolding']>
   flattenDepth?: number
+  maxDepth?: number
   printStats: boolean
 }): Promise<void> {
   const jsonContent = await readInput(config.input)
@@ -35,6 +36,7 @@ export async function encodeToToon(config: {
     indent: config.indent,
     keyFolding: config.keyFolding,
     flattenDepth: config.flattenDepth,
+    maxDepth: config.maxDepth,
   }
 
   // When printing stats, we need the full string for token counting
@@ -80,6 +82,7 @@ export async function decodeToJson(config: {
   indent: NonNullable<DecodeOptions['indent']>
   strict: NonNullable<DecodeOptions['strict']>
   expandPaths?: NonNullable<DecodeOptions['expandPaths']>
+  maxDepth?: number
 }): Promise<void> {
   // Path expansion requires full value in memory, so use non-streaming path
   if (config.expandPaths === 'safe') {
@@ -89,6 +92,7 @@ export async function decodeToJson(config: {
       indent: config.indent,
       strict: config.strict,
       expandPaths: config.expandPaths,
+      maxDepth: config.maxDepth,
     }
     const data = decode(toonContent, decodeOptions)
 
@@ -100,6 +104,7 @@ export async function decodeToJson(config: {
     const decodeStreamOptions: DecodeStreamOptions = {
       indent: config.indent,
       strict: config.strict,
+      maxDepth: config.maxDepth,
     }
 
     const events = decodeStream(lineSource, decodeStreamOptions)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -58,6 +58,10 @@ const args: ArgsDef = {
     type: 'string',
     description: 'Maximum folded segment count when key folding is enabled (default: Infinity)',
   },
+  maxDepth: {
+    type: 'string',
+    description: 'Maximum structural nesting depth for encode/decode (default: 1000, use Infinity to disable)',
+  },
   expandPaths: {
     type: 'string',
     description: 'Enable path expansion: off, safe (default: off)',
@@ -117,6 +121,8 @@ export const mainCommand: CommandDef<ArgsDef> = defineCommand({
       }
     }
 
+    const maxDepth = parseDepthLimit(args.maxDepth, 'maxDepth')
+
     // Validate `expandPaths`
     const expandPaths = args.expandPaths || 'off'
     if (expandPaths !== 'off' && expandPaths !== 'safe') {
@@ -134,6 +140,7 @@ export const mainCommand: CommandDef<ArgsDef> = defineCommand({
           indent,
           keyFolding: keyFolding as NonNullable<EncodeOptions['keyFolding']>,
           flattenDepth,
+          maxDepth,
           printStats: args.stats === true,
         })
       }
@@ -144,6 +151,7 @@ export const mainCommand: CommandDef<ArgsDef> = defineCommand({
           indent,
           strict: args.strict !== false,
           expandPaths: expandPaths as NonNullable<DecodeOptions['expandPaths']>,
+          maxDepth,
         })
       }
     }
@@ -153,3 +161,20 @@ export const mainCommand: CommandDef<ArgsDef> = defineCommand({
     }
   },
 })
+
+function parseDepthLimit(value: string | undefined, optionName: string): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (value === 'Infinity') {
+    return Number.POSITIVE_INFINITY
+  }
+
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${optionName} value: ${value}`)
+  }
+
+  return parsed
+}

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -345,6 +345,38 @@ describe('toon CLI', () => {
         cleanup()
       }
     })
+
+    it('rejects encode input deeper than --maxDepth', async () => {
+      const cleanup = mockStdin(JSON.stringify({ a: { b: { c: true } } }))
+      const consolaError = vi.spyOn(consola, 'error').mockImplementation(() => undefined)
+      const exitSpy = vi.mocked(process.exit)
+
+      try {
+        await runCli({ rawArgs: ['--maxDepth', '1'] })
+
+        expect(exitSpy).toHaveBeenCalledWith(1)
+        expect(consolaError).toHaveBeenCalledWith(expect.stringContaining('maxDepth'))
+      }
+      finally {
+        cleanup()
+      }
+    })
+
+    it('rejects decode input deeper than --maxDepth', async () => {
+      const cleanup = mockStdin('a:\n  b:\n    c: true\n')
+      const consolaError = vi.spyOn(consola, 'error').mockImplementation(() => undefined)
+      const exitSpy = vi.mocked(process.exit)
+
+      try {
+        await runCli({ rawArgs: ['--decode', '--maxDepth', '1'] })
+
+        expect(exitSpy).toHaveBeenCalledWith(1)
+        expect(consolaError).toHaveBeenCalledWith(expect.stringContaining('Maximum nesting depth'))
+      }
+      finally {
+        cleanup()
+      }
+    })
   })
 
   describe('encode options', () => {

--- a/packages/toon/src/constants.ts
+++ b/packages/toon/src/constants.ts
@@ -56,3 +56,9 @@ export type Delimiter = typeof DELIMITERS[DelimiterKey]
 export const DEFAULT_DELIMITER: Delimiter = DELIMITERS.comma
 
 // #endregion
+
+// #region Limits
+
+export const DEFAULT_MAX_DEPTH = 1000
+
+// #endregion

--- a/packages/toon/src/decode/decoders.ts
+++ b/packages/toon/src/decode/decoders.ts
@@ -1,13 +1,14 @@
 import type { ArrayHeaderInfo, DecodeStreamOptions, Depth, JsonPrimitive, JsonStreamEvent, ParsedLine } from '../types.ts'
 import type { StreamingScanState } from './scanner.ts'
 import { COLON, DEFAULT_DELIMITER, LIST_ITEM_MARKER, LIST_ITEM_PREFIX } from '../constants.ts'
+import { formatMaxDepth, resolveMaxDepth } from '../shared/depth.ts'
 import { findClosingQuote } from '../shared/string-utils.ts'
 import { ToonDecodeError, withLine } from './errors.ts'
 import { isArrayHeaderContent, isKeyValueContent, mapRowValuesToPrimitives, parseArrayHeaderLine, parseDelimitedValues, parseKeyToken, parsePrimitiveToken } from './parser.ts'
 import { createScanState, parseLinesAsync, parseLinesSync } from './scanner.ts'
 import { assertExpectedCount, validateNoBlankLinesInRange, validateNoExtraListItems, validateNoExtraTabularRows } from './validation.ts'
 
-interface DecoderContext { indent: number, strict: boolean }
+interface DecoderContext { indent: number, strict: boolean, maxDepth: number }
 
 // #region Streaming line cursor
 
@@ -122,10 +123,7 @@ export function* decodeStreamSync(
     throw new Error('expandPaths is not supported in streaming decode')
   }
 
-  const resolvedOptions: DecoderContext = {
-    indent: options?.indent ?? 2,
-    strict: options?.strict ?? true,
-  }
+  const resolvedOptions = createDecoderContext(options)
 
   const scanState = createScanState()
   const lineGenerator = parseLinesSync(source, resolvedOptions.indent, resolvedOptions.strict, scanState)
@@ -139,6 +137,7 @@ export function* decodeStreamSync(
     yield { type: 'endObject' }
     return
   }
+  assertDecodeDepth(first.depth, resolvedOptions, first)
 
   if (first.content.trim() === '[]') {
     cursor.advanceSync()
@@ -152,7 +151,7 @@ export function* decodeStreamSync(
     const headerInfo = withLine(first, () => parseArrayHeaderLine(first.content, DEFAULT_DELIMITER, resolvedOptions.strict))
     if (headerInfo) {
       cursor.advanceSync()
-      yield* decodeArrayFromHeaderSync(headerInfo.header, headerInfo.inlineValues, cursor, 0, resolvedOptions, first)
+      yield* decodeArrayFromHeaderSync(headerInfo.header, headerInfo.inlineValues, cursor, 0, resolvedOptions, first, 0)
       return
     }
   }
@@ -176,7 +175,7 @@ export function* decodeStreamSync(
   // Root object
   const rootSeenKeys = resolvedOptions.strict ? new Set<string>() : undefined
   yield { type: 'startObject' }
-  yield* decodeKeyValueSync(first, cursor, 0, resolvedOptions, rootSeenKeys)
+  yield* decodeKeyValueSync(first, cursor, 0, resolvedOptions, 0, rootSeenKeys)
 
   // Process remaining object fields
   while (!cursor.atEndSync()) {
@@ -186,7 +185,7 @@ export function* decodeStreamSync(
     }
 
     cursor.advanceSync()
-    yield* decodeKeyValueSync(line, cursor, 0, resolvedOptions, rootSeenKeys)
+    yield* decodeKeyValueSync(line, cursor, 0, resolvedOptions, 0, rootSeenKeys)
   }
 
   yield { type: 'endObject' }
@@ -209,16 +208,19 @@ function* decodeKeyValueSync(
   cursor: StreamingLineCursor,
   baseDepth: Depth,
   options: DecoderContext,
+  parentObjectDepth: Depth,
   seenKeys?: Set<string>,
 ): Generator<JsonStreamEvent> {
   const content = line.content
+  assertDecodeDepth(line.depth, options, line)
+  assertDecodeDepth(parentObjectDepth, options, line)
 
   // Check for array header first
   const arrayHeader = withLine(line, () => parseArrayHeaderLine(content, DEFAULT_DELIMITER, options.strict))
   if (arrayHeader && arrayHeader.header.key !== undefined) {
     assertNoDuplicateKey(arrayHeader.header.key, line, seenKeys)
     yield { type: 'key', key: arrayHeader.header.key }
-    yield* decodeArrayFromHeaderSync(arrayHeader.header, arrayHeader.inlineValues, cursor, baseDepth, options, line)
+    yield* decodeArrayFromHeaderSync(arrayHeader.header, arrayHeader.inlineValues, cursor, baseDepth, options, line, parentObjectDepth + 1)
     return
   }
 
@@ -233,9 +235,12 @@ function* decodeKeyValueSync(
   // No value after colon - expect nested object or empty
   if (!rest) {
     const nextLine = cursor.peekSync()
+    const childObjectDepth = parentObjectDepth + 1
+    assertDecodeDepth(childObjectDepth, options, nextLine ?? line)
     if (nextLine && nextLine.depth > baseDepth) {
+      assertDecodeDepth(nextLine.depth, options, nextLine)
       yield { type: 'startObject' }
-      yield* decodeObjectFieldsSync(cursor, baseDepth + 1, options)
+      yield* decodeObjectFieldsSync(cursor, baseDepth + 1, options, childObjectDepth)
       yield { type: 'endObject' }
       return
     }
@@ -247,6 +252,7 @@ function* decodeKeyValueSync(
   }
 
   if (rest === '[]') {
+    assertDecodeDepth(parentObjectDepth + 1, options, line)
     yield { type: 'startArray', length: 0 }
     yield { type: 'endArray' }
     return
@@ -260,6 +266,7 @@ function* decodeObjectFieldsSync(
   cursor: StreamingLineCursor,
   baseDepth: Depth,
   options: DecoderContext,
+  objectDepth: Depth,
 ): Generator<JsonStreamEvent> {
   let computedDepth: Depth | undefined
   const seenKeys = options.strict ? new Set<string>() : undefined
@@ -269,6 +276,7 @@ function* decodeObjectFieldsSync(
     if (!line || line.depth < baseDepth) {
       break
     }
+    assertDecodeDepth(line.depth, options, line)
 
     if (computedDepth === undefined && line.depth >= baseDepth) {
       computedDepth = line.depth
@@ -276,7 +284,7 @@ function* decodeObjectFieldsSync(
 
     if (line.depth === computedDepth) {
       cursor.advanceSync()
-      yield* decodeKeyValueSync(line, cursor, computedDepth, options, seenKeys)
+      yield* decodeKeyValueSync(line, cursor, computedDepth, options, objectDepth, seenKeys)
     }
     else {
       break
@@ -291,7 +299,10 @@ function* decodeArrayFromHeaderSync(
   baseDepth: Depth,
   options: DecoderContext,
   headerLine: ParsedLine,
+  arrayDepth: Depth,
 ): Generator<JsonStreamEvent> {
+  assertDecodeDepth(headerLine.depth, options, headerLine)
+  assertDecodeDepth(arrayDepth, options, headerLine)
   yield { type: 'startArray', length: header.length }
 
   // Inline primitive array
@@ -303,13 +314,13 @@ function* decodeArrayFromHeaderSync(
 
   // Tabular array
   if (header.fields && header.fields.length > 0) {
-    yield* decodeTabularArraySync(header, cursor, baseDepth, options, headerLine)
+    yield* decodeTabularArraySync(header, cursor, baseDepth, options, headerLine, arrayDepth)
     yield { type: 'endArray' }
     return
   }
 
   // List array
-  yield* decodeListArraySync(header, cursor, baseDepth, options, headerLine)
+  yield* decodeListArraySync(header, cursor, baseDepth, options, headerLine, arrayDepth)
   yield { type: 'endArray' }
 }
 
@@ -340,6 +351,7 @@ function* decodeTabularArraySync(
   baseDepth: Depth,
   options: DecoderContext,
   headerLine: ParsedLine,
+  arrayDepth: Depth,
 ): Generator<JsonStreamEvent> {
   const rowDepth = baseDepth + 1
   let rowCount = 0
@@ -354,6 +366,8 @@ function* decodeTabularArraySync(
     }
 
     if (line.depth === rowDepth) {
+      assertDecodeDepth(line.depth, options, line)
+      assertDecodeDepth(arrayDepth + 1, options, line)
       if (startLine === undefined) {
         startLine = line.lineNumber
       }
@@ -365,7 +379,7 @@ function* decodeTabularArraySync(
       assertExpectedCount(values.length, header.fields!.length, 'tabular row values', options, line)
 
       const primitives = withLine(line, () => mapRowValuesToPrimitives(values))
-      yield* yieldObjectFromFields(header.fields!, primitives)
+      yield* yieldObjectFromFields(header.fields!, primitives, arrayDepth + 1, options, line)
 
       rowCount++
     }
@@ -392,6 +406,7 @@ function* decodeListArraySync(
   baseDepth: Depth,
   options: DecoderContext,
   headerLine: ParsedLine,
+  arrayDepth: Depth,
 ): Generator<JsonStreamEvent> {
   const itemDepth = baseDepth + 1
   let itemCount = 0
@@ -404,6 +419,7 @@ function* decodeListArraySync(
     if (!line || line.depth < itemDepth) {
       break
     }
+    assertDecodeDepth(line.depth, options, line)
 
     const isListItem = line.content.startsWith(LIST_ITEM_PREFIX) || line.content === LIST_ITEM_MARKER
 
@@ -414,7 +430,7 @@ function* decodeListArraySync(
       endLine = line.lineNumber
       lastItemLine = line
 
-      yield* decodeListItemSync(cursor, itemDepth, options)
+      yield* decodeListItemSync(cursor, itemDepth, options, arrayDepth + 1)
 
       const currentLine = cursor.current()
       if (currentLine) {
@@ -445,16 +461,19 @@ function* decodeListItemSync(
   cursor: StreamingLineCursor,
   baseDepth: Depth,
   options: DecoderContext,
+  itemValueDepth: Depth,
 ): Generator<JsonStreamEvent> {
   const line = cursor.nextSync()
   if (!line) {
     throw new ReferenceError('Expected list item')
   }
+  assertDecodeDepth(line.depth, options, line)
 
   let afterHyphen: string
 
   if (line.content === LIST_ITEM_MARKER) {
     // Bare list item marker: always an empty object
+    assertDecodeDepth(itemValueDepth, options, line)
     yield { type: 'startObject' }
     yield { type: 'endObject' }
     return
@@ -470,12 +489,14 @@ function* decodeListItemSync(
   }
 
   if (!afterHyphen.trim()) {
+    assertDecodeDepth(itemValueDepth, options, line)
     yield { type: 'startObject' }
     yield { type: 'endObject' }
     return
   }
 
   if (afterHyphen.trim() === '[]') {
+    assertDecodeDepth(itemValueDepth, options, line)
     yield { type: 'startArray', length: 0 }
     yield { type: 'endArray' }
     return
@@ -487,7 +508,7 @@ function* decodeListItemSync(
   if (isArrayHeaderContent(afterHyphen)) {
     const arrayHeader = withLine(itemLine, () => parseArrayHeaderLine(afterHyphen, DEFAULT_DELIMITER, options.strict))
     if (arrayHeader) {
-      yield* decodeArrayFromHeaderSync(arrayHeader.header, arrayHeader.inlineValues, cursor, baseDepth, options, itemLine)
+      yield* decodeArrayFromHeaderSync(arrayHeader.header, arrayHeader.inlineValues, cursor, baseDepth, options, itemLine, itemValueDepth)
       return
     }
   }
@@ -498,11 +519,12 @@ function* decodeListItemSync(
     // Object with tabular array as first field
     const header = headerInfo.header
     const seenKeys = options.strict ? new Set<string>([header.key!]) : undefined
+    assertDecodeDepth(itemValueDepth, options, itemLine)
     yield { type: 'startObject' }
     yield { type: 'key', key: header.key! }
 
     // Use baseDepth + 1 for the array so rows are at baseDepth + 2
-    yield* decodeArrayFromHeaderSync(header, headerInfo.inlineValues, cursor, baseDepth + 1, options, itemLine)
+    yield* decodeArrayFromHeaderSync(header, headerInfo.inlineValues, cursor, baseDepth + 1, options, itemLine, itemValueDepth + 1)
 
     // Read sibling fields at depth = baseDepth + 1
     const followDepth = baseDepth + 1
@@ -514,7 +536,7 @@ function* decodeListItemSync(
 
       if (nextLine.depth === followDepth && !nextLine.content.startsWith(LIST_ITEM_PREFIX)) {
         cursor.advanceSync()
-        yield* decodeKeyValueSync(nextLine, cursor, followDepth, options, seenKeys)
+        yield* decodeKeyValueSync(nextLine, cursor, followDepth, options, itemValueDepth, seenKeys)
       }
       else {
         break
@@ -528,8 +550,9 @@ function* decodeListItemSync(
   // Check for object first field after hyphen
   if (isKeyValueContent(afterHyphen)) {
     const seenKeys = options.strict ? new Set<string>() : undefined
+    assertDecodeDepth(itemValueDepth, options, itemLine)
     yield { type: 'startObject' }
-    yield* decodeKeyValueSync(itemLine, cursor, baseDepth + 1, options, seenKeys)
+    yield* decodeKeyValueSync(itemLine, cursor, baseDepth + 1, options, itemValueDepth, seenKeys)
 
     // Read subsequent fields
     const followDepth = baseDepth + 1
@@ -541,7 +564,7 @@ function* decodeListItemSync(
 
       if (nextLine.depth === followDepth && !nextLine.content.startsWith(LIST_ITEM_PREFIX)) {
         cursor.advanceSync()
-        yield* decodeKeyValueSync(nextLine, cursor, followDepth, options, seenKeys)
+        yield* decodeKeyValueSync(nextLine, cursor, followDepth, options, itemValueDepth, seenKeys)
       }
       else {
         break
@@ -583,10 +606,7 @@ export async function* decodeStream(
     throw new Error('expandPaths is not supported in streaming decode')
   }
 
-  const resolvedOptions = {
-    indent: options?.indent ?? 2,
-    strict: options?.strict ?? true,
-  }
+  const resolvedOptions = createDecoderContext(options)
 
   const scanState = createScanState()
 
@@ -603,6 +623,7 @@ export async function* decodeStream(
       yield { type: 'endObject' }
       return
     }
+    assertDecodeDepth(first.depth, resolvedOptions, first)
 
     if (first.content.trim() === '[]') {
       await cursor.advance()
@@ -616,7 +637,7 @@ export async function* decodeStream(
       const headerInfo = withLine(first, () => parseArrayHeaderLine(first.content, DEFAULT_DELIMITER, resolvedOptions.strict))
       if (headerInfo) {
         await cursor.advance()
-        yield* decodeArrayFromHeaderAsync(headerInfo.header, headerInfo.inlineValues, cursor, 0, resolvedOptions, first)
+        yield* decodeArrayFromHeaderAsync(headerInfo.header, headerInfo.inlineValues, cursor, 0, resolvedOptions, first, 0)
         return
       }
     }
@@ -639,7 +660,7 @@ export async function* decodeStream(
     // Root object
     const rootSeenKeys = resolvedOptions.strict ? new Set<string>() : undefined
     yield { type: 'startObject' }
-    yield* decodeKeyValueAsync(first, cursor, 0, resolvedOptions, rootSeenKeys)
+    yield* decodeKeyValueAsync(first, cursor, 0, resolvedOptions, 0, rootSeenKeys)
 
     // Process remaining object fields
     while (!(await cursor.atEnd())) {
@@ -648,7 +669,7 @@ export async function* decodeStream(
         break
       }
       await cursor.advance()
-      yield* decodeKeyValueAsync(line, cursor, 0, resolvedOptions, rootSeenKeys)
+      yield* decodeKeyValueAsync(line, cursor, 0, resolvedOptions, 0, rootSeenKeys)
     }
 
     yield { type: 'endObject' }
@@ -664,16 +685,19 @@ async function* decodeKeyValueAsync(
   cursor: StreamingLineCursor,
   baseDepth: Depth,
   options: DecoderContext,
+  parentObjectDepth: Depth,
   seenKeys?: Set<string>,
 ): AsyncGenerator<JsonStreamEvent> {
   const content = line.content
+  assertDecodeDepth(line.depth, options, line)
+  assertDecodeDepth(parentObjectDepth, options, line)
 
   // Check for array header first
   const arrayHeader = withLine(line, () => parseArrayHeaderLine(content, DEFAULT_DELIMITER, options.strict))
   if (arrayHeader && arrayHeader.header.key !== undefined) {
     assertNoDuplicateKey(arrayHeader.header.key, line, seenKeys)
     yield { type: 'key', key: arrayHeader.header.key }
-    yield* decodeArrayFromHeaderAsync(arrayHeader.header, arrayHeader.inlineValues, cursor, baseDepth, options, line)
+    yield* decodeArrayFromHeaderAsync(arrayHeader.header, arrayHeader.inlineValues, cursor, baseDepth, options, line, parentObjectDepth + 1)
     return
   }
 
@@ -688,9 +712,12 @@ async function* decodeKeyValueAsync(
   // No value after colon - expect nested object or empty
   if (!rest) {
     const nextLine = await cursor.peek()
+    const childObjectDepth = parentObjectDepth + 1
+    assertDecodeDepth(childObjectDepth, options, nextLine ?? line)
     if (nextLine && nextLine.depth > baseDepth) {
+      assertDecodeDepth(nextLine.depth, options, nextLine)
       yield { type: 'startObject' }
-      yield* decodeObjectFieldsAsync(cursor, baseDepth + 1, options)
+      yield* decodeObjectFieldsAsync(cursor, baseDepth + 1, options, childObjectDepth)
       yield { type: 'endObject' }
       return
     }
@@ -702,6 +729,7 @@ async function* decodeKeyValueAsync(
   }
 
   if (rest === '[]') {
+    assertDecodeDepth(parentObjectDepth + 1, options, line)
     yield { type: 'startArray', length: 0 }
     yield { type: 'endArray' }
     return
@@ -715,6 +743,7 @@ async function* decodeObjectFieldsAsync(
   cursor: StreamingLineCursor,
   baseDepth: Depth,
   options: DecoderContext,
+  objectDepth: Depth,
 ): AsyncGenerator<JsonStreamEvent> {
   let computedDepth: Depth | undefined
   const seenKeys = options.strict ? new Set<string>() : undefined
@@ -724,6 +753,7 @@ async function* decodeObjectFieldsAsync(
     if (!line || line.depth < baseDepth) {
       break
     }
+    assertDecodeDepth(line.depth, options, line)
 
     if (computedDepth === undefined && line.depth >= baseDepth) {
       computedDepth = line.depth
@@ -731,7 +761,7 @@ async function* decodeObjectFieldsAsync(
 
     if (line.depth === computedDepth) {
       await cursor.advance()
-      yield* decodeKeyValueAsync(line, cursor, computedDepth, options, seenKeys)
+      yield* decodeKeyValueAsync(line, cursor, computedDepth, options, objectDepth, seenKeys)
     }
     else {
       break
@@ -746,7 +776,10 @@ async function* decodeArrayFromHeaderAsync(
   baseDepth: Depth,
   options: DecoderContext,
   headerLine: ParsedLine,
+  arrayDepth: Depth,
 ): AsyncGenerator<JsonStreamEvent> {
+  assertDecodeDepth(headerLine.depth, options, headerLine)
+  assertDecodeDepth(arrayDepth, options, headerLine)
   yield { type: 'startArray', length: header.length }
 
   // Inline primitive array
@@ -758,13 +791,13 @@ async function* decodeArrayFromHeaderAsync(
 
   // Tabular array
   if (header.fields && header.fields.length > 0) {
-    yield* decodeTabularArrayAsync(header, cursor, baseDepth, options, headerLine)
+    yield* decodeTabularArrayAsync(header, cursor, baseDepth, options, headerLine, arrayDepth)
     yield { type: 'endArray' }
     return
   }
 
   // List array
-  yield* decodeListArrayAsync(header, cursor, baseDepth, options, headerLine)
+  yield* decodeListArrayAsync(header, cursor, baseDepth, options, headerLine, arrayDepth)
   yield { type: 'endArray' }
 }
 
@@ -774,6 +807,7 @@ async function* decodeTabularArrayAsync(
   baseDepth: Depth,
   options: DecoderContext,
   headerLine: ParsedLine,
+  arrayDepth: Depth,
 ): AsyncGenerator<JsonStreamEvent> {
   const rowDepth = baseDepth + 1
   let rowCount = 0
@@ -788,6 +822,8 @@ async function* decodeTabularArrayAsync(
     }
 
     if (line.depth === rowDepth) {
+      assertDecodeDepth(line.depth, options, line)
+      assertDecodeDepth(arrayDepth + 1, options, line)
       if (startLine === undefined) {
         startLine = line.lineNumber
       }
@@ -799,7 +835,7 @@ async function* decodeTabularArrayAsync(
       assertExpectedCount(values.length, header.fields!.length, 'tabular row values', options, line)
 
       const primitives = withLine(line, () => mapRowValuesToPrimitives(values))
-      yield* yieldObjectFromFields(header.fields!, primitives)
+      yield* yieldObjectFromFields(header.fields!, primitives, arrayDepth + 1, options, line)
 
       rowCount++
     }
@@ -826,6 +862,7 @@ async function* decodeListArrayAsync(
   baseDepth: Depth,
   options: DecoderContext,
   headerLine: ParsedLine,
+  arrayDepth: Depth,
 ): AsyncGenerator<JsonStreamEvent> {
   const itemDepth = baseDepth + 1
   let itemCount = 0
@@ -838,6 +875,7 @@ async function* decodeListArrayAsync(
     if (!line || line.depth < itemDepth) {
       break
     }
+    assertDecodeDepth(line.depth, options, line)
 
     const isListItem = line.content.startsWith(LIST_ITEM_PREFIX) || line.content === LIST_ITEM_MARKER
 
@@ -848,7 +886,7 @@ async function* decodeListArrayAsync(
       endLine = line.lineNumber
       lastItemLine = line
 
-      yield* decodeListItemAsync(cursor, itemDepth, options)
+      yield* decodeListItemAsync(cursor, itemDepth, options, arrayDepth + 1)
 
       const currentLine = cursor.current()
       if (currentLine) {
@@ -879,16 +917,19 @@ async function* decodeListItemAsync(
   cursor: StreamingLineCursor,
   baseDepth: Depth,
   options: DecoderContext,
+  itemValueDepth: Depth,
 ): AsyncGenerator<JsonStreamEvent> {
   const line = await cursor.next()
   if (!line) {
     throw new ReferenceError('Expected list item')
   }
+  assertDecodeDepth(line.depth, options, line)
 
   let afterHyphen: string
 
   if (line.content === LIST_ITEM_MARKER) {
     // Bare list item marker: always an empty object
+    assertDecodeDepth(itemValueDepth, options, line)
     yield { type: 'startObject' }
     yield { type: 'endObject' }
     return
@@ -904,12 +945,14 @@ async function* decodeListItemAsync(
   }
 
   if (!afterHyphen.trim()) {
+    assertDecodeDepth(itemValueDepth, options, line)
     yield { type: 'startObject' }
     yield { type: 'endObject' }
     return
   }
 
   if (afterHyphen.trim() === '[]') {
+    assertDecodeDepth(itemValueDepth, options, line)
     yield { type: 'startArray', length: 0 }
     yield { type: 'endArray' }
     return
@@ -921,7 +964,7 @@ async function* decodeListItemAsync(
   if (isArrayHeaderContent(afterHyphen)) {
     const arrayHeader = withLine(itemLine, () => parseArrayHeaderLine(afterHyphen, DEFAULT_DELIMITER, options.strict))
     if (arrayHeader) {
-      yield* decodeArrayFromHeaderAsync(arrayHeader.header, arrayHeader.inlineValues, cursor, baseDepth, options, itemLine)
+      yield* decodeArrayFromHeaderAsync(arrayHeader.header, arrayHeader.inlineValues, cursor, baseDepth, options, itemLine, itemValueDepth)
       return
     }
   }
@@ -932,11 +975,12 @@ async function* decodeListItemAsync(
     // Object with tabular array as first field
     const header = headerInfo.header
     const seenKeys = options.strict ? new Set<string>([header.key!]) : undefined
+    assertDecodeDepth(itemValueDepth, options, itemLine)
     yield { type: 'startObject' }
     yield { type: 'key', key: header.key! }
 
     // Use baseDepth + 1 for the array so rows are at baseDepth + 2
-    yield* decodeArrayFromHeaderAsync(header, headerInfo.inlineValues, cursor, baseDepth + 1, options, itemLine)
+    yield* decodeArrayFromHeaderAsync(header, headerInfo.inlineValues, cursor, baseDepth + 1, options, itemLine, itemValueDepth + 1)
 
     // Read sibling fields at depth = baseDepth + 1
     const followDepth = baseDepth + 1
@@ -948,7 +992,7 @@ async function* decodeListItemAsync(
 
       if (nextLine.depth === followDepth && !nextLine.content.startsWith(LIST_ITEM_PREFIX)) {
         await cursor.advance()
-        yield* decodeKeyValueAsync(nextLine, cursor, followDepth, options, seenKeys)
+        yield* decodeKeyValueAsync(nextLine, cursor, followDepth, options, itemValueDepth, seenKeys)
       }
       else {
         break
@@ -962,8 +1006,9 @@ async function* decodeListItemAsync(
   // Check for object first field after hyphen
   if (isKeyValueContent(afterHyphen)) {
     const seenKeys = options.strict ? new Set<string>() : undefined
+    assertDecodeDepth(itemValueDepth, options, itemLine)
     yield { type: 'startObject' }
-    yield* decodeKeyValueAsync(itemLine, cursor, baseDepth + 1, options, seenKeys)
+    yield* decodeKeyValueAsync(itemLine, cursor, baseDepth + 1, options, itemValueDepth, seenKeys)
 
     // Read subsequent fields
     const followDepth = baseDepth + 1
@@ -975,7 +1020,7 @@ async function* decodeListItemAsync(
 
       if (nextLine.depth === followDepth && !nextLine.content.startsWith(LIST_ITEM_PREFIX)) {
         await cursor.advance()
-        yield* decodeKeyValueAsync(nextLine, cursor, followDepth, options, seenKeys)
+        yield* decodeKeyValueAsync(nextLine, cursor, followDepth, options, itemValueDepth, seenKeys)
       }
       else {
         break
@@ -997,13 +1042,34 @@ async function* decodeListItemAsync(
 function* yieldObjectFromFields(
   fields: string[],
   primitives: JsonPrimitive[],
+  objectDepth: Depth,
+  options: DecoderContext,
+  line: ParsedLine,
 ): Generator<JsonStreamEvent> {
+  assertDecodeDepth(objectDepth, options, line)
   yield { type: 'startObject' }
   for (let i = 0; i < fields.length; i++) {
     yield { type: 'key', key: fields[i]! }
     yield { type: 'primitive', value: primitives[i]! }
   }
   yield { type: 'endObject' }
+}
+
+function createDecoderContext(options?: DecodeStreamOptions): DecoderContext {
+  return {
+    indent: options?.indent ?? 2,
+    strict: options?.strict ?? true,
+    maxDepth: resolveMaxDepth(options?.maxDepth),
+  }
+}
+
+function assertDecodeDepth(depth: Depth, options: DecoderContext, line: ParsedLine): void {
+  if (depth > options.maxDepth) {
+    throw new ToonDecodeError(
+      `Maximum nesting depth of ${formatMaxDepth(options.maxDepth)} exceeded`,
+      { line: line.lineNumber, source: line.raw },
+    )
+  }
 }
 
 // #endregion

--- a/packages/toon/src/decode/expand.ts
+++ b/packages/toon/src/decode/expand.ts
@@ -1,6 +1,7 @@
 import type { JsonObject, JsonValue } from '../types.ts'
 import { DOT } from '../constants.ts'
 import { isJsonObject } from '../encode/normalize.ts'
+import { assertMaxDepth } from '../shared/depth.ts'
 import { isIdentifierSegment } from '../shared/validation.ts'
 
 // #region Path expansion (safe)
@@ -37,16 +38,25 @@ export interface ObjectWithQuotedKeys extends JsonObject {
  *
  * @param value - The decoded value to expand
  * @param strict - Whether to throw errors on conflicts
+ * @param maxDepth - Maximum structural nesting depth to produce
+ * @param depth - Current structural nesting depth
  * @returns The expanded value with dotted keys reconstructed as nested objects
  * @throws TypeError if conflicts occur in strict mode
  */
-export function expandPathsSafe(value: JsonValue, strict: boolean): JsonValue {
+export function expandPathsSafe(
+  value: JsonValue,
+  strict: boolean,
+  maxDepth: number = Number.POSITIVE_INFINITY,
+  depth = 0,
+): JsonValue {
   if (Array.isArray(value)) {
+    assertDecodeExpansionDepth(depth, maxDepth)
     // Recursively expand array elements
-    return value.map(item => expandPathsSafe(item, strict))
+    return value.map(item => expandPathsSafe(item, strict, maxDepth, depth + 1))
   }
 
   if (isJsonObject(value)) {
+    assertDecodeExpansionDepth(depth, maxDepth)
     const expandedObject: JsonObject = {}
 
     // Check if this object has quoted key metadata
@@ -62,15 +72,16 @@ export function expandPathsSafe(value: JsonValue, strict: boolean): JsonValue {
 
         // Validate all segments are identifiers
         if (segments.every(seg => isIdentifierSegment(seg))) {
+          assertDecodeExpansionDepth(depth + segments.length - 1, maxDepth)
           // Expand this dotted key
-          const expandedValue = expandPathsSafe(keyValue, strict)
+          const expandedValue = expandPathsSafe(keyValue, strict, maxDepth, depth + segments.length)
           insertPathSafe(expandedObject, segments, expandedValue, strict)
           continue
         }
       }
 
       // Not expandable - keep as literal key, but still recursively expand the value
-      const expandedValue = expandPathsSafe(keyValue, strict)
+      const expandedValue = expandPathsSafe(keyValue, strict, maxDepth, depth + 1)
 
       // Check for conflicts with already-expanded keys
       if (key in expandedObject) {
@@ -230,6 +241,10 @@ function mergeObjects(
 
 function canMerge(a: JsonValue, b: JsonValue): a is JsonObject {
   return isJsonObject(a) && isJsonObject(b)
+}
+
+function assertDecodeExpansionDepth(depth: number, maxDepth: number): void {
+  assertMaxDepth(depth, maxDepth, 'Decoded value nesting')
 }
 
 // #endregion

--- a/packages/toon/src/encode/encoders.ts
+++ b/packages/toon/src/encode/encoders.ts
@@ -1,5 +1,6 @@
 import type { Depth, JsonArray, JsonObject, JsonPrimitive, JsonValue, ResolvedEncodeOptions } from '../types.ts'
 import { DOT, LIST_ITEM_MARKER, LIST_ITEM_PREFIX } from '../constants.ts'
+import { assertMaxDepth } from '../shared/depth.ts'
 import { tryFoldKeyChain } from './folding.ts'
 import { isArrayOfArrays, isArrayOfObjects, isArrayOfPrimitives, isEmptyObject, isJsonArray, isJsonObject, isJsonPrimitive } from './normalize.ts'
 import { encodeAndJoinPrimitives, encodeKey, encodePrimitive, formatHeader } from './primitives.ts'
@@ -7,6 +8,8 @@ import { encodeAndJoinPrimitives, encodeKey, encodePrimitive, formatHeader } fro
 // #region Encode normalized JsonValue
 
 export function* encodeJsonValue(value: JsonValue, options: ResolvedEncodeOptions, depth: Depth): Generator<string> {
+  assertEncodeDepth(depth, options)
+
   if (isJsonPrimitive(value)) {
     // Primitives at root level are returned as a single line
     const encodedPrimitive = encodePrimitive(value, options.delimiter)
@@ -37,6 +40,8 @@ export function* encodeObjectLines(
   pathPrefix?: string,
   remainingDepth?: number,
 ): Generator<string> {
+  assertEncodeDepth(depth, options)
+
   const keys = Object.keys(value)
 
   // At root level (depth 0), collect all literal dotted keys for collision checking
@@ -61,6 +66,8 @@ export function* encodeKeyValuePairLines(
   pathPrefix?: string,
   flattenDepth?: number,
 ): Generator<string> {
+  assertEncodeDepth(depth, options)
+
   const currentPath = pathPrefix ? `${pathPrefix}${DOT}${key}` : key
   const effectiveFlattenDepth = flattenDepth ?? options.flattenDepth
 
@@ -70,6 +77,7 @@ export function* encodeKeyValuePairLines(
 
     if (foldResult) {
       const { foldedKey, remainder, leafValue, segmentCount } = foldResult
+      assertEncodeDepth(depth + segmentCount - 1, options)
       const encodedFoldedKey = encodeKey(foldedKey)
 
       // Case 1: Fully folded to a leaf value
@@ -127,6 +135,8 @@ export function* encodeArrayLines(
   depth: Depth,
   options: ResolvedEncodeOptions,
 ): Generator<string> {
+  assertEncodeDepth(depth, options)
+
   if (value.length === 0) {
     const line = key != null ? `${encodeKey(key)}: []` : '[]'
     yield indentedLine(depth, line, options.indent)
@@ -175,6 +185,8 @@ export function* encodeArrayOfArraysAsListItemsLines(
   depth: Depth,
   options: ResolvedEncodeOptions,
 ): Generator<string> {
+  assertEncodeDepth(depth, options)
+
   const header = formatHeader(values.length, { key: prefix, delimiter: options.delimiter })
   yield indentedLine(depth, header, options.indent)
 
@@ -207,6 +219,8 @@ export function* encodeArrayOfObjectsAsTabularLines(
   depth: Depth,
   options: ResolvedEncodeOptions,
 ): Generator<string> {
+  assertEncodeDepth(depth, options)
+
   const formattedHeader = formatHeader(rows.length, { key: prefix, fields: header, delimiter: options.delimiter })
   yield indentedLine(depth, formattedHeader, options.indent)
 
@@ -259,6 +273,8 @@ function* writeTabularRowsLines(
   depth: Depth,
   options: ResolvedEncodeOptions,
 ): Generator<string> {
+  assertEncodeDepth(depth, options)
+
   for (const row of rows) {
     const values = header.map(key => row[key])
     const joinedValue = encodeAndJoinPrimitives(values as JsonPrimitive[], options.delimiter)
@@ -276,6 +292,8 @@ export function* encodeMixedArrayAsListItemsLines(
   depth: Depth,
   options: ResolvedEncodeOptions,
 ): Generator<string> {
+  assertEncodeDepth(depth, options)
+
   const header = formatHeader(items.length, { key: prefix, delimiter: options.delimiter })
   yield indentedLine(depth, header, options.indent)
 
@@ -289,6 +307,8 @@ export function* encodeObjectAsListItemLines(
   depth: Depth,
   options: ResolvedEncodeOptions,
 ): Generator<string> {
+  assertEncodeDepth(depth, options)
+
   if (isEmptyObject(obj)) {
     yield indentedLine(depth, LIST_ITEM_MARKER, options.indent)
     return
@@ -365,6 +385,8 @@ function* encodeListItemValueLines(
   depth: Depth,
   options: ResolvedEncodeOptions,
 ): Generator<string> {
+  assertEncodeDepth(depth, options)
+
   if (isJsonPrimitive(value)) {
     yield indentedListItem(depth, encodePrimitive(value, options.delimiter), options.indent)
   }
@@ -397,6 +419,10 @@ function indentedLine(depth: Depth, content: string, indentSize: number): string
 
 function indentedListItem(depth: Depth, content: string, indentSize: number): string {
   return indentedLine(depth, LIST_ITEM_PREFIX + content, indentSize)
+}
+
+function assertEncodeDepth(depth: Depth, options: ResolvedEncodeOptions): void {
+  assertMaxDepth(depth, options.maxDepth, 'Encoded value nesting')
 }
 
 // #endregion

--- a/packages/toon/src/encode/normalize.ts
+++ b/packages/toon/src/encode/normalize.ts
@@ -1,8 +1,13 @@
 import type { JsonArray, JsonObject, JsonPrimitive, JsonValue } from '../types.ts'
+import { assertMaxDepth } from '../shared/depth.ts'
 
 // #region Normalization (unknown → JsonValue)
 
-export function normalizeValue(value: unknown): JsonValue {
+export function normalizeValue(
+  value: unknown,
+  maxDepth: number = Number.POSITIVE_INFINITY,
+  depth = 0,
+): JsonValue {
   // null
   if (value === null) {
     return null
@@ -18,7 +23,7 @@ export function normalizeValue(value: unknown): JsonValue {
     const next = value.toJSON()
     // Avoid infinite recursion when toJSON returns the same object
     if (next !== value) {
-      return normalizeValue(next)
+      return normalizeValue(next, maxDepth, depth)
     }
   }
 
@@ -55,28 +60,32 @@ export function normalizeValue(value: unknown): JsonValue {
 
   // Array
   if (Array.isArray(value)) {
-    return value.map(normalizeValue)
+    assertMaxDepth(depth, maxDepth, 'Encoded value nesting')
+    return value.map(item => normalizeValue(item, maxDepth, depth + 1))
   }
 
   // Set → array
   if (value instanceof Set) {
-    return Array.from(value).map(normalizeValue)
+    assertMaxDepth(depth, maxDepth, 'Encoded value nesting')
+    return Array.from(value).map(item => normalizeValue(item, maxDepth, depth + 1))
   }
 
   // Map → object
   if (value instanceof Map) {
+    assertMaxDepth(depth, maxDepth, 'Encoded value nesting')
     return Object.fromEntries(
-      Array.from(value, ([k, v]) => [String(k), normalizeValue(v)]),
+      Array.from(value, ([k, v]) => [String(k), normalizeValue(v, maxDepth, depth + 1)]),
     )
   }
 
   // Plain object
   if (isPlainObject(value)) {
+    assertMaxDepth(depth, maxDepth, 'Encoded value nesting')
     const encodedValues: Record<string, JsonValue> = {}
 
     for (const key in value) {
       if (Object.hasOwn(value, key)) {
-        encodedValues[key] = normalizeValue(value[key])
+        encodedValues[key] = normalizeValue(value[key], maxDepth, depth + 1)
       }
     }
 

--- a/packages/toon/src/encode/replacer.ts
+++ b/packages/toon/src/encode/replacer.ts
@@ -1,4 +1,5 @@
 import type { EncodeReplacer, JsonArray, JsonObject, JsonValue } from '../types.ts'
+import { assertMaxDepth } from '../shared/depth.ts'
 import { isJsonArray, isJsonObject, normalizeValue } from './normalize.ts'
 
 /**
@@ -13,20 +14,24 @@ import { isJsonArray, isJsonObject, normalizeValue } from './normalize.ts'
  * @param replacer - The replacer function to apply
  * @returns The transformed `JsonValue`
  */
-export function applyReplacer(root: JsonValue, replacer: EncodeReplacer): JsonValue {
+export function applyReplacer(
+  root: JsonValue,
+  replacer: EncodeReplacer,
+  maxDepth: number = Number.POSITIVE_INFINITY,
+): JsonValue {
   // Call replacer on root with empty string key and empty path
   const replacedRoot = replacer('', root, [])
 
   // For root, undefined means "no change" (don't omit the root)
   if (replacedRoot === undefined) {
-    return transformChildren(root, replacer, [])
+    return transformChildren(root, replacer, [], maxDepth)
   }
 
   // Normalize the replaced value (in case user returned non-JsonValue)
-  const normalizedRoot = normalizeValue(replacedRoot)
+  const normalizedRoot = normalizeValue(replacedRoot, maxDepth)
 
   // Recursively transform children
-  return transformChildren(normalizedRoot, replacer, [])
+  return transformChildren(normalizedRoot, replacer, [], maxDepth)
 }
 
 /**
@@ -41,13 +46,16 @@ function transformChildren(
   value: JsonValue,
   replacer: EncodeReplacer,
   path: readonly (string | number)[],
+  maxDepth: number,
 ): JsonValue {
   if (isJsonObject(value)) {
-    return transformObject(value, replacer, path)
+    assertMaxDepth(path.length, maxDepth, 'Encoded value nesting')
+    return transformObject(value, replacer, path, maxDepth)
   }
 
   if (isJsonArray(value)) {
-    return transformArray(value, replacer, path)
+    assertMaxDepth(path.length, maxDepth, 'Encoded value nesting')
+    return transformArray(value, replacer, path, maxDepth)
   }
 
   // Primitives have no children
@@ -66,6 +74,7 @@ function transformObject(
   obj: JsonObject,
   replacer: EncodeReplacer,
   path: readonly (string | number)[],
+  maxDepth: number,
 ): JsonObject {
   const result: Record<string, JsonValue> = {}
 
@@ -80,10 +89,10 @@ function transformObject(
     }
 
     // Normalize the replaced value
-    const normalizedValue = normalizeValue(replacedValue)
+    const normalizedValue = normalizeValue(replacedValue, maxDepth, childPath.length)
 
     // Recursively transform children of the replaced value
-    result[key] = transformChildren(normalizedValue, replacer, childPath)
+    result[key] = transformChildren(normalizedValue, replacer, childPath, maxDepth)
   }
 
   return result
@@ -101,6 +110,7 @@ function transformArray(
   arr: JsonArray,
   replacer: EncodeReplacer,
   path: readonly (string | number)[],
+  maxDepth: number,
 ): JsonArray {
   const result: JsonValue[] = []
 
@@ -116,10 +126,10 @@ function transformArray(
     }
 
     // Normalize the replaced value
-    const normalizedValue = normalizeValue(replacedValue)
+    const normalizedValue = normalizeValue(replacedValue, maxDepth, childPath.length)
 
     // Recursively transform children of the replaced value
-    result.push(transformChildren(normalizedValue, replacer, childPath))
+    result.push(transformChildren(normalizedValue, replacer, childPath, maxDepth))
   }
 
   return result

--- a/packages/toon/src/index.ts
+++ b/packages/toon/src/index.ts
@@ -6,8 +6,9 @@ import { expandPathsSafe } from './decode/expand.ts'
 import { encodeJsonValue } from './encode/encoders.ts'
 import { normalizeValue } from './encode/normalize.ts'
 import { applyReplacer } from './encode/replacer.ts'
+import { resolveMaxDepth } from './shared/depth.ts'
 
-export { DEFAULT_DELIMITER, DELIMITERS } from './constants.ts'
+export { DEFAULT_DELIMITER, DEFAULT_MAX_DEPTH, DELIMITERS } from './constants.ts'
 export { ToonDecodeError } from './decode/errors.ts'
 export type {
   DecodeOptions,
@@ -104,12 +105,12 @@ export function decode(input: string, options?: DecodeOptions): JsonValue {
  * ```
  */
 export function encodeLines(input: unknown, options?: EncodeOptions): Iterable<string> {
-  const normalizedValue = normalizeValue(input)
   const resolvedOptions = resolveOptions(options)
+  const normalizedValue = normalizeValue(input, resolvedOptions.maxDepth)
 
   // Apply replacer if provided
   const maybeReplacedValue = resolvedOptions.replacer
-    ? applyReplacer(normalizedValue, resolvedOptions.replacer)
+    ? applyReplacer(normalizedValue, resolvedOptions.replacer, resolvedOptions.maxDepth)
     : normalizedValue
 
   return encodeJsonValue(maybeReplacedValue, resolvedOptions, 0)
@@ -140,6 +141,7 @@ export function decodeFromLines(lines: Iterable<string>, options?: DecodeOptions
   const streamOptions: DecodeStreamOptions = {
     indent: resolvedOptions.indent,
     strict: resolvedOptions.strict,
+    maxDepth: resolvedOptions.maxDepth,
   }
 
   const events = decodeStreamSyncCore(lines, streamOptions)
@@ -147,7 +149,7 @@ export function decodeFromLines(lines: Iterable<string>, options?: DecodeOptions
 
   // Apply path expansion if enabled
   if (resolvedOptions.expandPaths === 'safe') {
-    return expandPathsSafe(decodedValue, resolvedOptions.strict)
+    return expandPathsSafe(decodedValue, resolvedOptions.strict, resolvedOptions.maxDepth)
   }
 
   return decodedValue
@@ -225,6 +227,7 @@ function resolveOptions(options?: EncodeOptions): ResolvedEncodeOptions {
     delimiter: options?.delimiter ?? DEFAULT_DELIMITER,
     keyFolding: options?.keyFolding ?? 'off',
     flattenDepth: options?.flattenDepth ?? Number.POSITIVE_INFINITY,
+    maxDepth: resolveMaxDepth(options?.maxDepth),
     replacer: options?.replacer,
   }
 }
@@ -234,5 +237,6 @@ function resolveDecodeOptions(options?: DecodeOptions): ResolvedDecodeOptions {
     indent: options?.indent ?? 2,
     strict: options?.strict ?? true,
     expandPaths: options?.expandPaths ?? 'off',
+    maxDepth: resolveMaxDepth(options?.maxDepth),
   }
 }

--- a/packages/toon/src/shared/depth.ts
+++ b/packages/toon/src/shared/depth.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_MAX_DEPTH } from '../constants.ts'
+
+export function resolveMaxDepth(maxDepth: number | undefined): number {
+  const resolved = maxDepth ?? DEFAULT_MAX_DEPTH
+
+  if (resolved === Number.POSITIVE_INFINITY) {
+    return resolved
+  }
+
+  if (!Number.isInteger(resolved) || resolved < 0) {
+    throw new RangeError('maxDepth must be a non-negative integer or Infinity')
+  }
+
+  return resolved
+}
+
+export function assertMaxDepth(depth: number, maxDepth: number, label: string): void {
+  if (depth > maxDepth) {
+    throw new RangeError(`${label} exceeds maxDepth of ${formatMaxDepth(maxDepth)}`)
+  }
+}
+
+export function formatMaxDepth(maxDepth: number): string {
+  return maxDepth === Number.POSITIVE_INFINITY ? 'Infinity' : String(maxDepth)
+}

--- a/packages/toon/src/types.ts
+++ b/packages/toon/src/types.ts
@@ -75,6 +75,11 @@ export interface EncodeOptions {
    */
   flattenDepth?: number
   /**
+   * Maximum structural nesting depth to encode. Use Infinity to disable the limit.
+   * @default 1000
+   */
+  maxDepth?: number
+  /**
    * A function to transform or filter values during encoding.
    * Called for the root value and every nested property/element.
    * Return `undefined` to omit properties/elements (root cannot be omitted).
@@ -108,6 +113,11 @@ export interface DecodeOptions {
    * @default 'off'
    */
   expandPaths?: 'off' | 'safe'
+  /**
+   * Maximum structural nesting depth to decode. Use Infinity to disable the limit.
+   * @default 1000
+   */
+  maxDepth?: number
 }
 
 export type ResolvedDecodeOptions = Readonly<Required<DecodeOptions>>

--- a/packages/toon/test/depth-limits.test.ts
+++ b/packages/toon/test/depth-limits.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { decode, decodeStream, decodeStreamSync, encode, ToonDecodeError } from '../src/index'
+
+describe('depth limits', () => {
+  it('rejects encode input deeper than the default maxDepth', () => {
+    expect(() => encode(createNestedObject(1001))).toThrow(RangeError)
+    expect(() => encode(createNestedObject(1001))).toThrow(/maxDepth/)
+  })
+
+  it('honors custom encode maxDepth values', () => {
+    expect(() => encode(createNestedObject(2), { maxDepth: 2 })).not.toThrow()
+    expect(() => encode(createNestedObject(2), { maxDepth: 1 })).toThrow(RangeError)
+  })
+
+  it('checks values returned by replacer before encoding them', () => {
+    expect(() => encode({ value: 'replace' }, {
+      maxDepth: 1,
+      replacer(key, value) {
+        if (key === 'value') {
+          return createNestedObject(2)
+        }
+        return value
+      },
+    })).toThrow(RangeError)
+  })
+
+  it('allows trusted encode callers to disable the depth limit', () => {
+    expect(() => encode(createNestedObject(20), { maxDepth: Infinity })).not.toThrow()
+  })
+
+  it('rejects decode input deeper than the default maxDepth', () => {
+    expect(() => decode(createNestedToon(1001))).toThrow(ToonDecodeError)
+    expect(() => decode(createNestedToon(1001))).toThrow(/Maximum nesting depth/)
+  })
+
+  it('honors custom decode maxDepth values', () => {
+    expect(() => decode(createNestedToon(2), { maxDepth: 2 })).not.toThrow()
+    expect(() => decode(createNestedToon(2), { maxDepth: 1 })).toThrow(ToonDecodeError)
+  })
+
+  it('counts keyed inline containers as nested decode values', () => {
+    expect(() => decode('items: []', { maxDepth: 0 })).toThrow(ToonDecodeError)
+    expect(() => decode('items: []', { maxDepth: 1 })).not.toThrow()
+  })
+
+  it('counts tabular row objects as nested decode values', () => {
+    const input = 'items[1]{name}:\n  Alice'
+
+    expect(() => decode(input, { maxDepth: 1 })).toThrow(ToonDecodeError)
+    expect(() => decode(input, { maxDepth: 2 })).not.toThrow()
+  })
+
+  it('applies maxDepth to safe path expansion', () => {
+    expect(decode('a.b.c: true', { expandPaths: 'safe', maxDepth: 2 })).toEqual({
+      a: {
+        b: {
+          c: true,
+        },
+      },
+    })
+    expect(() => decode('a.b.c: true', { expandPaths: 'safe', maxDepth: 1 })).toThrow(RangeError)
+  })
+
+  it('applies maxDepth in synchronous streaming decode', () => {
+    const lines = createNestedToon(2).split('\n')
+
+    expect(() => Array.from(decodeStreamSync(lines, { maxDepth: 1 }))).toThrow(ToonDecodeError)
+    expect(() => Array.from(decodeStreamSync(['items[1]{name}:', '  Alice'], { maxDepth: 1 }))).toThrow(ToonDecodeError)
+  })
+
+  it('applies maxDepth in asynchronous streaming decode', async () => {
+    const lines = createNestedToon(2).split('\n')
+
+    await expect(collect(decodeStream(asyncLines(lines), { maxDepth: 1 }))).rejects.toThrow(ToonDecodeError)
+  })
+
+  it('validates maxDepth options', () => {
+    expect(() => encode({}, { maxDepth: -1 })).toThrow(RangeError)
+    expect(() => decode('a: 1', { maxDepth: 1.5 })).toThrow(RangeError)
+  })
+})
+
+function createNestedObject(depth: number): unknown {
+  let value: unknown = true
+
+  for (let i = depth; i >= 0; i--) {
+    value = { [`level${i}`]: value }
+  }
+
+  return value
+}
+
+function createNestedToon(depth: number): string {
+  const lines: string[] = []
+
+  for (let i = 0; i < depth; i++) {
+    lines.push(`${'  '.repeat(i)}level${i}:`)
+  }
+  lines.push(`${'  '.repeat(depth)}value: true`)
+
+  return lines.join('\n')
+}
+
+async function* asyncLines(lines: readonly string[]): AsyncIterable<string> {
+  for (const line of lines) {
+    yield line
+  }
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const items: T[] = []
+
+  for await (const item of iterable) {
+    items.push(item)
+  }
+
+  return items
+}

--- a/packages/toon/test/encode.test.ts
+++ b/packages/toon/test/encode.test.ts
@@ -49,5 +49,6 @@ function resolveEncodeOptions(options?: TestCase['options']): ResolvedEncodeOpti
     delimiter: options?.delimiter ?? DEFAULT_DELIMITER,
     keyFolding: options?.keyFolding ?? 'off',
     flattenDepth: options?.flattenDepth ?? Number.POSITIVE_INFINITY,
+    maxDepth: options?.maxDepth ?? 1000,
   }
 }

--- a/packages/toon/test/types.ts
+++ b/packages/toon/test/types.ts
@@ -16,6 +16,7 @@ export interface TestCase {
     strict?: boolean
     keyFolding?: 'off' | 'safe'
     flattenDepth?: number
+    maxDepth?: number
     expandPaths?: 'off' | 'safe'
   }
   specSection?: string


### PR DESCRIPTION
## Summary
- add a default `maxDepth` limit of 1000 for encode, decode, and streaming decode
- expose `maxDepth` through the TypeScript API and CLI, with `Infinity` as an explicit opt-out
- enforce the limit across normalization, replacer output, encoding, decoding, and safe dotted-path expansion
- update API/CLI docs and add regression tests for deep inputs, tabular rows, inline containers, streaming decode, and CLI forwarding

## Validation
- `nvm exec 24 corepack pnpm run lint`
- `nvm exec 24 corepack pnpm run test:types`
- `nvm exec 24 corepack pnpm run test`
- `nvm exec 24 corepack pnpm run build`
- `nvm exec 24 corepack pnpm run docs:build`
- `/Users/ckorhonen/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --codex-bin /Applications/Codex.app/Contents/Resources/codex`

Autoreview result: first run found one accepted P2 issue where decode counted source indentation instead of emitted container depth for tabular row objects and inline keyed containers. Fixed by tracking emitted JSON container depth and adding regressions. Final autoreview rerun was clean with no accepted/actionable findings.