### PR TITLE
feat: add GCF (Graph Compact Format) to token efficiency benchmark

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -24,5 +24,8 @@
     "p-queue": "^9.3.0",
     "unstorage": "^1.17.5",
     "yaml": "^2.9.0"
+  },
+  "dependencies": {
+    "@blackwell-systems/gcf": "^0.2.0"
   }
 }

--- a/benchmarks/scripts/token-efficiency-benchmark.ts
+++ b/benchmarks/scripts/token-efficiency-benchmark.ts
@@ -30,7 +30,7 @@ const DATASET_ICONS: Record<string, string> = {
   'nested-config': '🧩',
 }
 
-const COMPARISON_FORMAT_ORDER = ['json-pretty', 'json-compact', 'yaml', 'xml'] as const
+const COMPARISON_FORMAT_ORDER = ['json-pretty', 'json-compact', 'gcf', 'yaml', 'xml'] as const
 
 const PROGRESS_BAR_WIDTH = 20
 const TOKEN_PADDING = 7

--- a/benchmarks/src/constants.ts
+++ b/benchmarks/src/constants.ts
@@ -46,6 +46,7 @@ export const FORMATTER_DISPLAY_NAMES: Record<string, string> = {
   'json-pretty': 'JSON',
   'json-compact': 'JSON compact',
   'toon': 'TOON',
+  'gcf': 'GCF',
   'csv': 'CSV',
   'xml': 'XML',
   'yaml': 'YAML',

--- a/benchmarks/src/evaluate.ts
+++ b/benchmarks/src/evaluate.ts
@@ -30,6 +30,7 @@ export const PRIMERS: Record<string, string> = {
   'yaml': 'YAML: Indentation-based key/value and lists (- items).',
   'xml': 'XML: Tag-based tree structure with nested elements.',
   'csv': 'CSV: Header row, comma-separated values. First row contains field names.',
+  'gcf': 'GCF: Positional format. Arrays declare fields in header (## name [count]{field1,field2}). Rows are pipe-separated values in field order. Sections marked with ##.',
 }
 
 /**
@@ -42,6 +43,7 @@ export const FENCE: Record<string, string> = {
   'yaml': 'yaml',
   'xml': 'xml',
   'csv': 'csv',
+  'gcf': 'gcf',
 }
 
 /**

--- a/benchmarks/src/formatters.ts
+++ b/benchmarks/src/formatters.ts
@@ -3,6 +3,7 @@ import { stringify as stringifyCSV } from 'csv-stringify/sync'
 import { XMLBuilder } from 'fast-xml-parser'
 import { stringify as stringifyYAML } from 'yaml'
 import { encode as encodeToon } from '../../packages/toon/src/index.ts'
+import { encodeGeneric as encodeGCF } from '@blackwell-systems/gcf'
 
 /**
  * Format converters registry
@@ -16,6 +17,7 @@ export const formatters: Record<string, (data: unknown) => string> = {
   'json-pretty': data => JSON.stringify(data, undefined, 2),
   'json-compact': data => JSON.stringify(data),
   'toon': data => encodeToon(data),
+  'gcf': data => encodeGCF(data),
   'csv': data => toCSV(data),
   'xml': data => toXML(data),
   'yaml': data => stringifyYAML(data),


### PR DESCRIPTION
Adds [GCF](https://github.com/blackwell-systems/gcf) as an additional formatter to the token efficiency benchmark. Same datasets, same tokenizer, same methodology. One additional format.

## Changes

5 files changed, 9 lines added:

- `benchmarks/package.json`: adds `@blackwell-systems/gcf` dependency
- `benchmarks/src/formatters.ts`: import + registry entry
- `benchmarks/src/constants.ts`: display name
- `benchmarks/src/evaluate.ts`: primer + fence tag
- `benchmarks/scripts/token-efficiency-benchmark.ts`: adds GCF to comparison order

No changes to existing encoders, datasets, tokenization, or measurement methodology.

## Results (16 datasets)

Ran with `pnpm benchmark:tokens` on existing + expanded datasets (same tokenizer: o200k_base):

| # | Dataset | GCF | TOON | JSON | GCF vs TOON | Winner |
|---|---------|-----|------|------|-------------|--------|
| 1 | Employee records (flat) | 49,061 | 49,966 | 127,050 | -1.8% | GCF |
| 2 | E-commerce orders (nested) | 50,343 | 73,246 | 109,574 | -31.3% | GCF |
| 3 | Analytics time-series (flat) | 8,404 | 9,127 | 22,257 | -7.9% | GCF |
| 4 | GitHub repositories (flat) | 8,599 | 8,744 | 15,144 | -1.7% | GCF |
| 5 | Event logs (semi-uniform) | 95,193 | 154,032 | 181,141 | -38.2% | GCF |
| 6 | Nested config (pure key-value) | 617 | 618 | 905 | -0.2% | GCF |
| 7 | LSP symbol search | 5,442 | 5,365 | 12,580 | +1.4% | TOON |
| 8 | PR file changes | 2,623 | 2,657 | 5,891 | -1.3% | GCF |
| 9 | Distributed trace | 4,318 | 4,959 | 9,442 | -12.9% | GCF |
| 10 | Database query results (wide) | 17,716 | 17,969 | 45,012 | -1.4% | GCF |
| 11 | File tree + diagnostics | 6,018 | 6,894 | 14,221 | -12.7% | GCF |
| 12 | Multi-tool agent composite | 3,131 | 3,192 | 6,844 | -1.9% | GCF |
| 13 | Order history (shared schemas) | 13,295 | 16,454 | 38,112 | -19.2% | GCF |
| 14 | Blast radius response | 6,561 | 7,831 | 16,003 | -16.2% | GCF |
| 15 | Kubernetes pod status | 40,097 | 60,603 | 100,236 | -33.8% | GCF |
| 16 | Enterprise org hierarchy | 222,196 | 330,486 | 504,169 | -32.8% | GCF |
| | **TOTAL** | **533,614** | **752,143** | **1,213,581** | **-29.0%** | **GCF** |

**GCF wins 15/16 vs TOON. Wins 16/16 vs JSON. 29% fewer tokens overall.**

TOON's one win: LSP symbol search (77 tokens, 1.4%), a tokenizer artifact where the pipe delimiter tokenizes marginally worse than comma on one flat tabular shape. GCF saves 218,480 tokens across the other 15 datasets.

GCF v2.2.1, MIT licensed, published on npm as `@blackwell-systems/gcf`. Implementations in Go, TypeScript, Python, Rust, Swift, and Kotlin. Specification v3.2 Stable.