### PR TITLE
Issue 308 raw string support

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -272,6 +272,48 @@ The replacer is called in a depth-first manner:
 Following `JSON.stringify` behavior, array indices are passed as strings (`'0'`, `'1'`, `'2'`, etc.) to the replacer, not as numbers.
 :::
 
+### Raw String Output
+
+Return `rawString(...)` from a replacer to emit a string verbatim at the value position, bypassing TOON's quoting, escaping, and number/keyword detection. Compose it with `escapeString` to control quoting yourself without reimplementing escape handling.
+
+```ts
+import { encode, escapeString, rawString } from '@toon-format/toon'
+
+const data = { name: 'Ada', age: 30 }
+
+// Always-quote mode: wrap every leaf in quotes
+console.log(encode(data, {
+  replacer: (key, value) => rawString(`"${escapeString(String(value))}"`)
+}))
+```
+
+**Output:**
+
+<!-- eslint-skip -->
+
+```yaml
+name: "Ada"
+age: "30"
+```
+
+#### Semantics
+
+- A `rawString` is only honored where a primitive would go. Returned for an object or array value, it is ignored and the container is encoded normally – this lets "wrap every value" replacers recurse into containers instead of collapsing them.
+- A value containing a line whose first non-space character is `#` throws at `rawString(...)` time – regardless of where the value would be emitted – since decoders silently strip such comment lines and the data would vanish without an error.
+
+#### `escapeString(value)`
+
+Escapes backslashes, quotes, and control characters for use inside a quoted TOON string. The decision whether a value needs quoting at all stays with the caller.
+
+```ts
+escapeString('a "quoted" value') // a \"quoted\" value
+escapeString('line1\nline2') // line1\nline2 (escaped)
+```
+
+::: warning One-Way Escape Hatch
+Raw emission bypasses the encoder's correctness guarantees: the output is not guaranteed to be valid TOON or to round-trip losslessly. In the example above, `age` decodes back as the string `"30"`, not the number `30`.
+:::
+
 ## Decoding Functions
 
 ### `decode(input, options?)`

--- a/packages/toon/README.md
+++ b/packages/toon/README.md
@@ -809,7 +809,7 @@ const transformed = encode(data, {
 ```
 
 > [!TIP]
-> The `replacer` function provides fine-grained control over encoding, similar to `JSON.stringify`'s replacer but with path tracking. See the [API Reference](https://toonformat.dev/reference/api#replacer-function) for more examples.
+> The `replacer` function provides fine-grained control over encoding, similar to `JSON.stringify`'s replacer but with path tracking. See the [API Reference](https://toonformat.dev/reference/api#replacer-function) for more examples, including verbatim output with [`rawString`](https://toonformat.dev/reference/api#raw-string-output).
 
 ## Playgrounds
 

--- a/packages/toon/src/encode/encoders.ts
+++ b/packages/toon/src/encode/encoders.ts
@@ -1,12 +1,13 @@
-import type { Depth, FieldNode, JsonArray, JsonObject, JsonPrimitive, JsonValue, ResolvedEncodeOptions } from '../types.ts'
+import type { Depth, FieldNode, JsonArray, JsonObject, JsonValue, ResolvedEncodeOptions } from '../types.ts'
+import type { EncodablePrimitive } from './raw-string.ts'
 import { LIST_ITEM_MARKER, LIST_ITEM_PREFIX } from '../constants.ts'
-import { isArrayOfArrays, isArrayOfObjects, isArrayOfPrimitives, isEmptyObject, isJsonArray, isJsonObject, isJsonPrimitive } from './normalize.ts'
+import { isArrayOfArrays, isArrayOfObjects, isArrayOfPrimitives, isEmptyObject, isEncodablePrimitive, isJsonArray, isJsonObject } from './normalize.ts'
 import { encodeAndJoinPrimitives, encodeKey, encodePrimitive, formatHeader } from './primitives.ts'
 
 // #region Encode normalized JsonValue
 
 export function* encodeJsonValue(value: JsonValue, options: ResolvedEncodeOptions, depth: Depth): Generator<string> {
-  if (isJsonPrimitive(value)) {
+  if (isEncodablePrimitive(value)) {
     // Primitives at root level are returned as a single line
     const encodedPrimitive = encodePrimitive(value, options.delimiter)
 
@@ -53,7 +54,7 @@ export function* encodeKeyValuePairLines(
 ): Generator<string> {
   const encodedKey = encodeKey(key)
 
-  if (isJsonPrimitive(value)) {
+  if (isEncodablePrimitive(value)) {
     yield indentedLine(depth, `${encodedKey}: ${encodePrimitive(value, options.delimiter)}`, options.indent)
   }
   else if (isJsonArray(value)) {
@@ -111,7 +112,7 @@ function* encodeKeyedEntryRowsLines(
   options: ResolvedEncodeOptions,
 ): Generator<string> {
   for (const [entryKey, entryValue] of entries) {
-    const leaves: JsonPrimitive[] = []
+    const leaves: EncodablePrimitive[] = []
     collectLeafValues(entryValue as JsonObject, fields, leaves)
     yield indentedLine(depth, `${encodeKey(entryKey)}: ${encodeAndJoinPrimitives(leaves, options.delimiter)}`, options.indent)
   }
@@ -186,7 +187,7 @@ export function* encodeArrayOfArraysAsListItemsLines(
   }
 }
 
-export function encodeInlineArrayLine(values: readonly JsonPrimitive[], delimiter: string, prefix?: string): string {
+export function encodeInlineArrayLine(values: readonly EncodablePrimitive[], delimiter: string, prefix?: string): string {
   const header = formatHeader(values.length, { key: prefix, delimiter })
   const joinedValue = encodeAndJoinPrimitives(values, delimiter)
 
@@ -247,7 +248,7 @@ export function extractTabularHeader(rows: readonly JsonObject[]): FieldNode[] |
 
 function classifyColumn(name: string, values: readonly JsonValue[]): FieldNode | undefined {
   // Uniform-primitive column: a bare leaf field
-  if (values.every(value => isJsonPrimitive(value))) {
+  if (values.every(value => isEncodablePrimitive(value))) {
     return { name }
   }
 
@@ -265,14 +266,14 @@ function classifyColumn(name: string, values: readonly JsonValue[]): FieldNode |
   return { name, children }
 }
 
-function collectLeafValues(row: JsonObject, fields: readonly FieldNode[], leaves: JsonPrimitive[]): void {
+function collectLeafValues(row: JsonObject, fields: readonly FieldNode[], leaves: EncodablePrimitive[]): void {
   for (const field of fields) {
     const value = row[field.name]
     if (field.children) {
       collectLeafValues(value as JsonObject, field.children, leaves)
     }
     else {
-      leaves.push(value as JsonPrimitive)
+      leaves.push(value as EncodablePrimitive)
     }
   }
 }
@@ -284,7 +285,7 @@ function* writeTabularRowsLines(
   options: ResolvedEncodeOptions,
 ): Generator<string> {
   for (const row of rows) {
-    const leaves: JsonPrimitive[] = []
+    const leaves: EncodablePrimitive[] = []
     collectLeafValues(row, header, leaves)
     yield indentedLine(depth, encodeAndJoinPrimitives(leaves, options.delimiter), options.indent)
   }
@@ -359,7 +360,7 @@ export function* encodeObjectAsListItemLines(
 
   const encodedKey = encodeKey(firstKey)
 
-  if (isJsonPrimitive(firstValue)) {
+  if (isEncodablePrimitive(firstValue)) {
     // Primitive value: `- key: value`
     const encodedValue = encodePrimitive(firstValue, options.delimiter)
     yield indentedListItem(depth, `${encodedKey}: ${encodedValue}`, options.indent)
@@ -407,7 +408,7 @@ function* encodeListItemValueLines(
   depth: Depth,
   options: ResolvedEncodeOptions,
 ): Generator<string> {
-  if (isJsonPrimitive(value)) {
+  if (isEncodablePrimitive(value)) {
     yield indentedListItem(depth, encodePrimitive(value, options.delimiter), options.indent)
   }
   else if (isJsonArray(value)) {

--- a/packages/toon/src/encode/normalize.ts
+++ b/packages/toon/src/encode/normalize.ts
@@ -1,5 +1,7 @@
 import type { JsonArray, JsonObject, JsonPrimitive, JsonValue } from '../types.ts'
+import type { EncodablePrimitive } from './raw-string.ts'
 import { setOwnProperty } from '../shared/object-utils.ts'
+import { isRawString } from './raw-string.ts'
 
 // #region Normalization (unknown → JsonValue)
 
@@ -7,6 +9,12 @@ export function normalizeValue(value: unknown): JsonValue {
   // null
   if (value === null) {
     return null
+  }
+
+  // RawString markers pass through untouched; encode-side guards treat
+  // them as primitives, never as objects
+  if (isRawString(value)) {
+    return value as unknown as JsonValue
   }
 
   // Objects with toJSON: delegate to its result before host-type normalization
@@ -101,12 +109,16 @@ export function isJsonPrimitive(value: unknown): value is JsonPrimitive {
   )
 }
 
+export function isEncodablePrimitive(value: unknown): value is EncodablePrimitive {
+  return isJsonPrimitive(value) || isRawString(value)
+}
+
 export function isJsonArray(value: unknown): value is JsonArray {
   return Array.isArray(value)
 }
 
 export function isJsonObject(value: unknown): value is JsonObject {
-  return value !== null && typeof value === 'object' && !Array.isArray(value)
+  return value !== null && typeof value === 'object' && !Array.isArray(value) && !isRawString(value)
 }
 
 export function isEmptyObject(value: JsonObject): boolean {
@@ -126,8 +138,8 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 
 // #region Array type detection
 
-export function isArrayOfPrimitives(value: JsonArray): value is readonly JsonPrimitive[] {
-  return value.length === 0 || value.every(item => isJsonPrimitive(item))
+export function isArrayOfPrimitives(value: JsonArray | readonly EncodablePrimitive[]): value is readonly EncodablePrimitive[] {
+  return value.length === 0 || value.every(item => isEncodablePrimitive(item))
 }
 
 export function isArrayOfArrays(value: JsonArray): value is readonly JsonArray[] {

--- a/packages/toon/src/encode/primitives.ts
+++ b/packages/toon/src/encode/primitives.ts
@@ -1,11 +1,18 @@
-import type { FieldNode, JsonPrimitive } from '../types.ts'
+import type { FieldNode } from '../types.ts'
+import type { EncodablePrimitive } from './raw-string.ts'
 import { COMMA, DEFAULT_DELIMITER, DOUBLE_QUOTE, NULL_LITERAL } from '../constants.ts'
 import { escapeString } from '../shared/string-utils.ts'
 import { isSafeUnquoted, isValidUnquotedKey } from '../shared/validation.ts'
+import { isRawString } from './raw-string.ts'
 
 // #region Primitive encoding
 
-export function encodePrimitive(value: JsonPrimitive, delimiter?: string): string {
+export function encodePrimitive(value: EncodablePrimitive, delimiter?: string): string {
+  // RawString: pre-formatted output emitted verbatim
+  if (isRawString(value)) {
+    return value.value
+  }
+
   if (value === null) {
     return NULL_LITERAL
   }
@@ -45,7 +52,7 @@ export function encodeKey(key: string): string {
 
 // #region Value joining
 
-export function encodeAndJoinPrimitives(values: readonly JsonPrimitive[], delimiter: string = DEFAULT_DELIMITER): string {
+export function encodeAndJoinPrimitives(values: readonly EncodablePrimitive[], delimiter: string = DEFAULT_DELIMITER): string {
   return values.map(v => encodePrimitive(v, delimiter)).join(delimiter)
 }
 

--- a/packages/toon/src/encode/raw-string.ts
+++ b/packages/toon/src/encode/raw-string.ts
@@ -1,0 +1,43 @@
+import type { JsonPrimitive } from '../types.ts'
+
+/**
+ * Pre-formatted string that the encoder emits verbatim at a primitive value
+ * position, bypassing quoting, escaping, and number/keyword detection.
+ *
+ * Returned from a replacer for an object or array value, it is ignored and
+ * the container is encoded normally.
+ */
+export class RawString {
+  readonly value: string
+
+  constructor(value: string) {
+    this.value = value
+  }
+}
+
+/** Values the encoder can emit at a primitive position. */
+export type EncodablePrimitive = JsonPrimitive | RawString
+
+/**
+ * Wraps a pre-formatted string for verbatim emission, typically returned from
+ * an encode `replacer`. Compose with `escapeString` to control quoting yourself.
+ *
+ * @param value - The exact text to emit at the value position
+ * @returns A `RawString` marker honored at primitive value positions
+ *
+ * @example
+ * ```ts
+ * encode({ name: 'Ada', age: 30 }, {
+ *   replacer: (key, value) => rawString(`"${escapeString(String(value))}"`)
+ * })
+ * // name: "Ada"
+ * // age: "30"
+ * ```
+ */
+export function rawString(value: string): RawString {
+  return new RawString(value)
+}
+
+export function isRawString(value: unknown): value is RawString {
+  return value instanceof RawString
+}

--- a/packages/toon/src/encode/raw-string.ts
+++ b/packages/toon/src/encode/raw-string.ts
@@ -1,4 +1,9 @@
 import type { JsonPrimitive } from '../types.ts'
+import { COMMENT_MARKER } from '../constants.ts'
+
+// A line whose first non-space character is the comment marker would be
+// silently stripped by decoders, so raw output must never form one
+const COMMENT_LINE_PATTERN = new RegExp(`(?:^|\\n) *${COMMENT_MARKER}`)
 
 /**
  * Pre-formatted string that the encoder emits verbatim at a primitive value
@@ -11,6 +16,9 @@ export class RawString {
   readonly value: string
 
   constructor(value: string) {
+    if (COMMENT_LINE_PATTERN.test(value)) {
+      throw new TypeError(`Raw string must not contain a line starting with "${COMMENT_MARKER}": ${JSON.stringify(value)}`)
+    }
     this.value = value
   }
 }

--- a/packages/toon/src/encode/replacer.ts
+++ b/packages/toon/src/encode/replacer.ts
@@ -1,6 +1,7 @@
 import type { EncodeReplacer, JsonArray, JsonObject, JsonValue } from '../types.ts'
 import { setOwnProperty } from '../shared/object-utils.ts'
-import { isJsonArray, isJsonObject, normalizeValue } from './normalize.ts'
+import { isEncodablePrimitive, isJsonArray, isJsonObject, normalizeValue } from './normalize.ts'
+import { isRawString } from './raw-string.ts'
 
 /**
  * Applies a replacer function to a `JsonValue` and all its descendants.
@@ -23,11 +24,32 @@ export function applyReplacer(root: JsonValue, replacer: EncodeReplacer): JsonVa
     return transformChildren(root, replacer, [])
   }
 
-  // Normalize the replaced value (in case user returned non-JsonValue)
-  const normalizedRoot = normalizeValue(replacedRoot)
+  return transformReplaced(root, replacedRoot, replacer, [])
+}
 
-  // Recursively transform children
-  return transformChildren(normalizedRoot, replacer, [])
+/**
+ * Resolves a replacer's (non-`undefined`) return value at a single position.
+ *
+ * A `RawString` only stands in for a primitive: returned for an object or
+ * array value, it is ignored and the original container is traversed normally.
+ *
+ * @param original - The value at this position before replacement
+ * @param replaced - The replacer's return value
+ * @param replacer - The replacer function to apply
+ * @param path - Current path from root
+ */
+function transformReplaced(
+  original: JsonValue,
+  replaced: unknown,
+  replacer: EncodeReplacer,
+  path: readonly (string | number)[],
+): JsonValue {
+  if (isRawString(replaced) && !isEncodablePrimitive(original)) {
+    return transformChildren(original, replacer, path)
+  }
+
+  // Normalize the replaced value (in case user returned non-JsonValue)
+  return transformChildren(normalizeValue(replaced), replacer, path)
 }
 
 /**
@@ -80,11 +102,7 @@ function transformObject(
       continue
     }
 
-    // Normalize the replaced value
-    const normalizedValue = normalizeValue(replacedValue)
-
-    // Recursively transform children of the replaced value
-    setOwnProperty(result, key, transformChildren(normalizedValue, replacer, childPath))
+    setOwnProperty(result, key, transformReplaced(value, replacedValue, replacer, childPath))
   }
 
   return result
@@ -116,11 +134,7 @@ function transformArray(
       continue
     }
 
-    // Normalize the replaced value
-    const normalizedValue = normalizeValue(replacedValue)
-
-    // Recursively transform children of the replaced value
-    result.push(transformChildren(normalizedValue, replacer, childPath))
+    result.push(transformReplaced(value, replacedValue, replacer, childPath))
   }
 
   return result

--- a/packages/toon/src/index.ts
+++ b/packages/toon/src/index.ts
@@ -8,6 +8,9 @@ import { applyReplacer } from './encode/replacer.ts'
 
 export { DEFAULT_DELIMITER, DELIMITERS } from './constants.ts'
 export { ToonDecodeError } from './decode/errors.ts'
+export { rawString } from './encode/raw-string.ts'
+export type { RawString } from './encode/raw-string.ts'
+export { escapeString } from './shared/string-utils.ts'
 export type {
   DecodeOptions,
   DecodeStreamOptions,

--- a/packages/toon/test/raw-string.test.ts
+++ b/packages/toon/test/raw-string.test.ts
@@ -1,0 +1,101 @@
+import type { EncodeReplacer } from '../src/types'
+import { describe, expect, it } from 'vitest'
+import { decode, encode, escapeString, rawString } from '../src/index'
+
+describe('rawString', () => {
+  describe('verbatim emission', () => {
+    it('bypasses quoting, escaping, and number/keyword detection', () => {
+      const replacer: EncodeReplacer = (key, value) => typeof value === 'string' ? rawString(value) : value
+
+      expect(encode({ note: 'a, b, c' }, { replacer })).toBe('note: a, b, c')
+      expect(encode({ flag: 'true' }, { replacer })).toBe('flag: true')
+      expect(encode({ id: '007' }, { replacer })).toBe('id: 007')
+    })
+
+    it('emits a pre-quoted string as-is', () => {
+      const replacer: EncodeReplacer = (key, value) => typeof value === 'string' ? rawString(`"${value}"`) : value
+
+      expect(encode({ id: '123' }, { replacer })).toBe('id: "123"')
+    })
+
+    it('mixes raw and normal returns', () => {
+      const replacer: EncodeReplacer = (key, value) => key === 'price' ? rawString(`$${value}`) : value
+
+      expect(encode({ price: 9.99, qty: 2 }, { replacer })).toBe('price: $9.99\nqty: 2')
+    })
+
+    it('accepts raw values directly without a replacer', () => {
+      expect(encode({ a: rawString('RAW') })).toBe('a: RAW')
+      expect(encode(rawString('VERBATIM'))).toBe('VERBATIM')
+    })
+  })
+
+  describe('emission positions', () => {
+    it('encodes raw values in inline primitive arrays', () => {
+      const replacer: EncodeReplacer = (key, value) => typeof value === 'string' ? rawString(`"${value}"`) : value
+
+      expect(encode({ tags: ['x', 'y'] }, { replacer })).toBe('tags[2]: "x","y"')
+    })
+
+    it('encodes raw values in tabular rows', () => {
+      const replacer: EncodeReplacer = (key, value) => key === 'qty' ? rawString(`"${value}"`) : value
+      const input = { items: [{ sku: 'A1', qty: 2 }, { sku: 'B2', qty: 1 }] }
+
+      expect(encode(input, { replacer })).toBe('items[2]{sku,qty}:\n  A1,"2"\n  B2,"1"')
+    })
+
+    it('encodes raw values in keyed tabular entry rows', () => {
+      const replacer: EncodeReplacer = (key, value) => key === 'age' ? rawString(`"${value}"`) : value
+      const input = { users: { alice: { age: 30, city: 'Berlin' }, bob: { age: 25, city: 'Oslo' } } }
+
+      expect(encode(input, { replacer })).toBe('users[2:]{age,city}:\n  alice: "30",Berlin\n  bob: "25",Oslo')
+    })
+
+    it('encodes raw values in nested field group cells', () => {
+      const replacer: EncodeReplacer = (key, value) => key === 'country' ? rawString(`"${value}"`) : value
+      const input = {
+        orders: [
+          { id: 1, customer: { name: 'Alice', country: 'DK' }, total: 99 },
+          { id: 2, customer: { name: 'Bob', country: 'UK' }, total: 149 },
+        ],
+      }
+
+      expect(encode(input, { replacer })).toBe('orders[2]{id,customer{name,country},total}:\n  1,Alice,"DK",99\n  2,Bob,"UK",149')
+    })
+  })
+
+  describe('container handling', () => {
+    it('ignores raw values returned for containers and keeps traversing', () => {
+      const replacer: EncodeReplacer = (key, value) => rawString(`"${escapeString(String(value))}"`)
+
+      expect(encode({ name: 'Alice', age: 30 }, { replacer })).toBe('name: "Alice"\nage: "30"')
+    })
+
+    it('round-trips always-quote output with numbers decoded as strings', () => {
+      const replacer: EncodeReplacer = (key, value) => rawString(`"${escapeString(String(value))}"`)
+      const result = encode([{ id: 1, name: 'A' }], { replacer })
+
+      expect(result).toBe('[1]{id,name}:\n  "1","A"')
+      expect(decode(result)).toEqual([{ id: '1', name: 'A' }])
+    })
+  })
+
+})
+
+describe('escapeString', () => {
+  it('escapes quotes, backslashes, and control characters', () => {
+    expect(escapeString('Alice')).toBe('Alice')
+    expect(escapeString('a"b')).toBe('a\\"b')
+    expect(escapeString('a\\b')).toBe('a\\\\b')
+    expect(escapeString('a\nb')).toBe('a\\nb')
+    expect(escapeString('a\tb')).toBe('a\\tb')
+  })
+
+  it('composes with rawString for custom quoting', () => {
+    const replacer: EncodeReplacer = (key, value) => rawString(`"${escapeString(String(value))}"`)
+    const result = encode({ q: 'a"b' }, { replacer })
+
+    expect(result).toBe('q: "a\\"b"')
+    expect(decode(result)).toEqual({ q: 'a"b' })
+  })
+})

--- a/packages/toon/test/raw-string.test.ts
+++ b/packages/toon/test/raw-string.test.ts
@@ -80,6 +80,17 @@ describe('rawString', () => {
     })
   })
 
+  describe('comment-line rejection', () => {
+    it('throws when a line starts with the comment marker', () => {
+      expect(() => rawString('#hi')).toThrowError(TypeError)
+      expect(() => rawString('  # indented')).toThrowError(TypeError)
+      expect(() => rawString('note\n# hidden')).toThrowError(TypeError)
+    })
+
+    it('allows the comment marker after other content on the same line', () => {
+      expect(encode({ tag: rawString('a #tag') })).toBe('tag: a #tag')
+    })
+  })
 })
 
 describe('escapeString', () => {


### PR DESCRIPTION
## Linked Issue

Closes #308

## Description

The feature is to let toon output in a quoted way regardless of the type of the item, upon explicit argument is set. 

Example:

```ts
const replacer: EncodeReplacer = (_k, v) => (typeof v === 'string' ? rawString(`"${v}"`) : v)
expect(encode({ id: '123' }, { replacer })).toBe('id: "123"')
```

Previously it was outputting `'id: 123'`, with this change it's possible to output `'id: "123"'`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- `escapeString` is now exported from `toon-format/toon/index.ts`
- `RawString, rawString` is implemented and exported from `toon-format/toon/index.ts`.

## SPEC Compliance

- [ ] This PR implements/fixes spec compliance
- [ ] Spec section(s) affected:
- [ ] Spec version:

## Testing

- Test cases added: `raw-string.test.ts`

- [x] All existing tests pass
- [x] Added new tests for changes
- [x] Tests cover edge cases and spec compliance

## Pre-submission Checklist

- [x] My code follows the project's coding standards
- [x] I have run code formatting/linting tools
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
- [x] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe migration path below)

## Additional Context

The issue #308 has been implemented with this PR.

It was a requirement to let `toon` to output quoted strings when `replacer` is customized.