### PR TITLE
fix: colon lookup uses wrong offset for quoted keys

### DIFF
--- a/packages/toon/src/decode/decoders.ts
+++ b/packages/toon/src/decode/decoders.ts
@@ -223,8 +223,8 @@ function* decodeKeyValueSync(
   }
 
   // Regular key-value pair
-  const { key, isQuoted } = withLine(line, () => parseKeyToken(content, 0))
-  const colonIndex = content.indexOf(COLON, key.length)
+  const { key, end: keyEnd, isQuoted } = withLine(line, () => parseKeyToken(content, 0))
+  const colonIndex = content.indexOf(COLON, keyEnd)
   const rest = colonIndex >= 0 ? content.slice(colonIndex + 1).trim() : ''
 
   assertNoDuplicateKey(key, line, seenKeys)
@@ -678,8 +678,8 @@ async function* decodeKeyValueAsync(
   }
 
   // Regular key-value pair
-  const { key, isQuoted } = withLine(line, () => parseKeyToken(content, 0))
-  const colonIndex = content.indexOf(COLON, key.length)
+  const { key, end: keyEnd, isQuoted } = withLine(line, () => parseKeyToken(content, 0))
+  const colonIndex = content.indexOf(COLON, keyEnd)
   const rest = colonIndex >= 0 ? content.slice(colonIndex + 1).trim() : ''
 
   assertNoDuplicateKey(key, line, seenKeys)


### PR DESCRIPTION
Found a parsing bug in both the sync and async key-value decoders.

After \`parseKeyToken\` returns, the code uses \`key.length\` as the offset to search for the colon separator in the raw content. But \`key\` is the unescaped parsed value (without quotes), while \`content\` still has the raw quoted form. For a quoted key like \`"a:b"\`, \`key.length\` is 3 (\`a:b\`) but the raw content is \`"a:b":value\` — the colon search starts at position 3 and finds the colon inside the quoted key at position 4, producing wrong results.

\`parseKeyToken\` already returns an \`end\` offset that correctly accounts for quotes and escape characters, but it was being discarded. Now both decoders use \`result.end\` instead of \`key.length\`.