### PR TITLE
feat(benchmarks): add MiniMax model provider

### DIFF
--- a/benchmarks/.env.example
+++ b/benchmarks/.env.example
@@ -3,3 +3,15 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GOOGLE_GENERATIVE_AI_API_KEY=
 XAI_API_KEY=
+
+# MiniMax models are added when this key is set.
+MINIMAX_API_KEY=
+MINIMAX_API_REGION=global_en
+MINIMAX_API_PROTOCOL=anthropic
+
+# Optional base URL override. Supported public base URLs:
+# global_en/openai: https://api.minimax.io/v1
+# global_en/anthropic: https://api.minimax.io/anthropic
+# cn_zh/openai: https://api.minimaxi.com/v1
+# cn_zh/anthropic: https://api.minimaxi.com/anthropic
+# MINIMAX_API_BASE_URL=

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -57,6 +57,27 @@ Tests how well LLMs can answer questions about data in different formats (TOON, 
    cp .env.example .env
    ```
 
+To add `MiniMax-M3` and `MiniMax-M2.7` to the model selection, set `MINIMAX_API_KEY` and choose a region and API protocol:
+
+```bash
+MINIMAX_API_KEY=your-key
+MINIMAX_API_REGION=global_en
+MINIMAX_API_PROTOCOL=anthropic
+```
+
+The benchmark supports these public base URLs:
+
+| Region | Protocol | Base URL |
+| --- | --- | --- |
+| `global_en` | `openai` | `https://api.minimax.io/v1` |
+| `global_en` | `anthropic` | `https://api.minimax.io/anthropic` |
+| `cn_zh` | `openai` | `https://api.minimaxi.com/v1` |
+| `cn_zh` | `anthropic` | `https://api.minimaxi.com/anthropic` |
+
+Regional documentation is available for [global endpoints](https://platform.minimax.io/docs) and [mainland China endpoints](https://platform.minimaxi.com/docs).
+
+Set `MINIMAX_API_BASE_URL` only to override the default selected by `MINIMAX_API_REGION` and `MINIMAX_API_PROTOCOL`. Anthropic-compatible public base URLs must end in `/anthropic`; the adapter derives the internal request path without changing the configured public URL.
+
 ### Usage
 
 ```bash

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "benchmark:tokens": "node scripts/token-efficiency-benchmark.ts",
     "benchmark:accuracy": "node --env-file=.env scripts/accuracy-benchmark.ts",
-    "fetch:github-repos": "node scripts/fetch-github-repos.ts"
+    "fetch:github-repos": "node scripts/fetch-github-repos.ts",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.78",

--- a/benchmarks/src/evaluate.ts
+++ b/benchmarks/src/evaluate.ts
@@ -6,6 +6,7 @@ import { openai } from '@ai-sdk/openai'
 import { xai } from '@ai-sdk/xai'
 import { generateText } from 'ai'
 import { compareAnswers } from './normalize.ts'
+import { createMiniMaxModels } from './providers/minimax.ts'
 
 /**
  * Models used for evaluation
@@ -15,6 +16,7 @@ export const models: LanguageModelV3[] = [
   google('gemini-3-flash-preview'),
   openai('gpt-5-nano'),
   xai('grok-4-1-fast-non-reasoning'),
+  ...createMiniMaxModels(),
 ]
 
 /**

--- a/benchmarks/src/providers/minimax.test.ts
+++ b/benchmarks/src/providers/minimax.test.ts
@@ -1,0 +1,95 @@
+import type { OpenAIProviderSettings } from '@ai-sdk/openai'
+import { generateText } from 'ai'
+import { describe, expect, it } from 'vitest'
+import { createMiniMaxModels, MINIMAX_MODEL_IDS } from './minimax.ts'
+
+type FetchFunction = NonNullable<OpenAIProviderSettings['fetch']>
+
+describe('createMiniMaxModels', () => {
+  it('registers both supported model IDs', () => {
+    const models = createMiniMaxModels({
+      MINIMAX_API_KEY: 'test',
+      MINIMAX_API_PROTOCOL: 'openai',
+      MINIMAX_API_REGION: 'global_en',
+    })
+
+    expect(models.map(model => model.modelId)).toEqual(MINIMAX_MODEL_IDS)
+  })
+
+  it.each([
+    {
+      protocol: 'openai',
+      region: 'global_en',
+      expectedURL: 'https://api.minimax.io/v1/chat/completions',
+    },
+    {
+      protocol: 'openai',
+      region: 'cn_zh',
+      expectedURL: 'https://api.minimaxi.com/v1/chat/completions',
+    },
+    {
+      protocol: 'anthropic',
+      region: 'global_en',
+      expectedURL: 'https://api.minimax.io/anthropic/v1/messages',
+    },
+    {
+      protocol: 'anthropic',
+      region: 'cn_zh',
+      expectedURL: 'https://api.minimaxi.com/anthropic/v1/messages',
+    },
+  ])('sends $region $protocol requests to the configured endpoint', async ({ expectedURL, protocol, region }) => {
+    const requestURLs: string[] = []
+    const models = createMiniMaxModels({
+      MINIMAX_API_KEY: 'test',
+      MINIMAX_API_PROTOCOL: protocol,
+      MINIMAX_API_REGION: region,
+    }, createCaptureFetch(requestURLs))
+
+    await generateText({
+      model: models[0]!,
+      prompt: 'Respond with OK.',
+    })
+
+    expect(requestURLs).toEqual([expectedURL])
+  })
+})
+
+function createCaptureFetch(requestURLs: string[]): FetchFunction {
+  return async (input) => {
+    const url = input instanceof Request ? input.url : input.toString()
+    requestURLs.push(url)
+
+    const response = url.endsWith('/messages')
+      ? {
+          id: 'message-id',
+          type: 'message',
+          role: 'assistant',
+          model: MINIMAX_MODEL_IDS[0],
+          content: [{ type: 'text', text: 'OK' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }
+      : {
+          id: 'completion-id',
+          object: 'chat.completion',
+          created: 0,
+          model: MINIMAX_MODEL_IDS[0],
+          choices: [{
+            index: 0,
+            message: { role: 'assistant', content: 'OK' },
+            finish_reason: 'stop',
+          }],
+          usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
+          },
+        }
+
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/benchmarks/src/providers/minimax.ts
+++ b/benchmarks/src/providers/minimax.ts
@@ -1,0 +1,78 @@
+import type { OpenAIProviderSettings } from '@ai-sdk/openai'
+import type { LanguageModelV3 } from '@ai-sdk/provider'
+import process from 'node:process'
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { createOpenAI } from '@ai-sdk/openai'
+
+export const MINIMAX_MODEL_IDS = [
+  'MiniMax-M3',
+  'MiniMax-M2.7',
+] as const
+
+export const MINIMAX_ENDPOINTS = {
+  global_en: {
+    openai: 'https://api.minimax.io/v1',
+    anthropic: 'https://api.minimax.io/anthropic',
+  },
+  cn_zh: {
+    openai: 'https://api.minimaxi.com/v1',
+    anthropic: 'https://api.minimaxi.com/anthropic',
+  },
+} as const
+
+type MiniMaxRegion = keyof typeof MINIMAX_ENDPOINTS
+type MiniMaxProtocol = keyof (typeof MINIMAX_ENDPOINTS)[MiniMaxRegion]
+
+export function createMiniMaxModels(
+  env: NodeJS.ProcessEnv = process.env,
+  fetch?: OpenAIProviderSettings['fetch'],
+): LanguageModelV3[] {
+  const apiKey = env.MINIMAX_API_KEY
+  if (!apiKey)
+    return []
+
+  const region = env.MINIMAX_API_REGION ?? 'global_en'
+  if (!isMiniMaxRegion(region))
+    throw new Error(`Unsupported MiniMax API region: ${region}`)
+
+  const protocol = env.MINIMAX_API_PROTOCOL ?? 'anthropic'
+  if (!isMiniMaxProtocol(protocol))
+    throw new Error(`Unsupported MiniMax API protocol: ${protocol}`)
+
+  const configuredBaseURL = env.MINIMAX_API_BASE_URL || MINIMAX_ENDPOINTS[region][protocol]
+  const publicBaseURL = configuredBaseURL.replace(/\/$/, '')
+
+  if (protocol === 'anthropic') {
+    if (!publicBaseURL.endsWith('/anthropic'))
+      throw new Error('MiniMax Anthropic-compatible base URLs must end in /anthropic')
+
+    const provider = createAnthropic({
+      name: 'minimax.messages',
+      authToken: apiKey,
+      baseURL: `${publicBaseURL}/v1`,
+      fetch,
+    })
+
+    return MINIMAX_MODEL_IDS.map(modelId => provider(modelId))
+  }
+
+  if (!publicBaseURL.endsWith('/v1'))
+    throw new Error('MiniMax OpenAI-compatible base URLs must end in /v1')
+
+  const provider = createOpenAI({
+    name: 'minimax',
+    apiKey,
+    baseURL: publicBaseURL,
+    fetch,
+  })
+
+  return MINIMAX_MODEL_IDS.map(modelId => provider.chat(modelId))
+}
+
+function isMiniMaxRegion(value: string): value is MiniMaxRegion {
+  return value in MINIMAX_ENDPOINTS
+}
+
+function isMiniMaxProtocol(value: string): value is MiniMaxProtocol {
+  return value === 'openai' || value === 'anthropic'
+}


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry.

This adds both configured model IDs to the benchmark model selection when MINIMAX_API_KEY is present. It supports both configured regions and API protocols through environment settings, documents the public base URLs and regional documentation, and verifies generated request URLs with capture tests.

Checks:
- pnpm --filter @toon/benchmarks test
- pnpm run test:types
- pnpm run lint
- pnpm run test