### PR TITLE
fix(decode): keep quoted scalars opaque to array-header scanning

### DIFF
--- a/packages/toon/src/decode/parser.ts
+++ b/packages/toon/src/decode/parser.ts
@@ -33,8 +33,10 @@ export function parseArrayHeaderLine(
     bracketStart = content.indexOf(OPEN_BRACKET, keyEndIndex)
   }
   else {
-    // Unquoted key - find first bracket
-    bracketStart = content.indexOf(OPEN_BRACKET)
+    // Unquoted key - find first bracket, skipping any that live inside a
+    // quoted value (e.g. `a: "[2]: x"`), which must stay opaque to header
+    // scanning so the line is treated as a plain key-value pair.
+    bracketStart = findUnquotedChar(content, OPEN_BRACKET)
   }
 
   if (bracketStart === -1) {

--- a/packages/toon/test/decode.test.ts
+++ b/packages/toon/test/decode.test.ts
@@ -13,7 +13,7 @@ import rootForm from '@toon-format/spec/tests/fixtures/decode/root-form.json'
 import validationErrors from '@toon-format/spec/tests/fixtures/decode/validation-errors.json'
 import whitespace from '@toon-format/spec/tests/fixtures/decode/whitespace.json'
 import { describe, expect, it } from 'vitest'
-import { decode } from '../src/index'
+import { decode, encode } from '../src/index'
 
 const fixtureFiles = [
   primitives,
@@ -47,3 +47,34 @@ for (const fixtures of fixtureFiles) {
     }
   })
 }
+
+// Regression: a quoted string scalar must stay opaque to array-header scanning,
+// even when it contains a bracketed-index-shaped substring followed by a colon.
+// https://github.com/toon-format/toon/issues/324
+describe('quoted scalar with bracket/colon shape (issue #324)', () => {
+  const cases: Array<Record<string, unknown>> = [
+    { a: '[2]: x' },
+    { content: 'accept (process.argv[2]) and greet: name' },
+    { a: '[1]: only one' }, // count-match path: must not silently corrupt
+    {
+      id: '68f5c016',
+      content:
+        'It should accept the first CLI argument (process.argv[2]) and greet: name instead.',
+      kind: 1621,
+    },
+  ]
+
+  for (const value of cases) {
+    it(`round-trips ${JSON.stringify(value)}`, () => {
+      expect(decode(encode(value))).toEqual(value)
+    })
+  }
+
+  it('decodes the quoted value as a plain scalar, not an array header', () => {
+    expect(decode('a: "[2]: x"')).toEqual({ a: '[2]: x' })
+  })
+
+  it('still parses a genuine array header with an unquoted key', () => {
+    expect(decode('items[3]: 1,2,3')).toEqual({ items: [1, 2, 3] })
+  })
+})


### PR DESCRIPTION
## Linked Issue

Closes #324

## Description

`decode()` rejected `encode()`'s own output whenever a **quoted string scalar** contained a bracketed-index-shaped substring followed later by a colon (e.g. `a: "[2]: x"`), breaking the `decode(encode(x)) == x` round-trip.

### Root cause

In `parseArrayHeaderLine` (`src/decode/parser.ts`), the unquoted-key path located the array-length bracket with a plain `content.indexOf('[')`. That search does not respect quoting, so a `[` living inside a quoted **value** was picked up and the line was misparsed as an array header (`key[2]: ...`). Decoding then either threw (`Expected 2 inline array items, but got 1`) or, when the fake item count happened to match the value, silently corrupted the result.

### Fix

Use the existing `findUnquotedChar` helper (already used elsewhere in the parser) to locate the bracket, so brackets inside quoted strings are skipped. The line then falls through to normal key-value parsing and the quoted scalar stays opaque, as the spec requires. Genuine array headers with unquoted keys (`items[3]: 1,2,3`) are unaffected — their bracket is unquoted and still found.

The quoted-key path (bracket searched after the closing quote) already handled quoted keys correctly and is untouched. This is orthogonal to #314, which addresses the *unquoted* key/value case.

### Tests

Added a regression block in `test/decode.test.ts` covering both reproductions from the issue, the real-world Nostr payload, the count-match (silent-corruption) variant, and an assertion that a genuine unquoted-key array header still parses. Full suite: 526 passing; `eslint` and `tsc --noEmit` clean.
