### PR TITLE
docs: document decoder number precision

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -340,6 +340,29 @@ const data = decode(toon, {
 
 Returns a JavaScript value (object, array, or primitive) representing the parsed TOON data.
 
+#### Numeric Precision
+
+Unquoted numeric tokens decode to JavaScript `number` values and follow IEEE 754 double-precision semantics. Finite values that exceed JavaScript's available precision may be rounded, including integers outside the safe integer range:
+
+```ts
+import { decode } from '@toon-format/toon'
+
+decode('unsafe: 9007199254740993')
+// { unsafe: 9007199254740992 }
+```
+
+Numeric tokens that overflow the finite `number` range decode as strings. If an exact high-precision value must survive decoding, emit it as a quoted string. The encoder follows this policy automatically for `BigInt` values outside the safe integer range:
+
+```ts
+import { decode, encode } from '@toon-format/toon'
+
+decode('exact: "9007199254740993"')
+// { exact: '9007199254740993' }
+
+decode(encode({ exact: 9007199254740993n }))
+// { exact: '9007199254740993' }
+```
+
 #### Example
 
 ```ts

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -340,28 +340,7 @@ const data = decode(toon, {
 
 Returns a JavaScript value (object, array, or primitive) representing the parsed TOON data.
 
-#### Numeric Precision
-
-Unquoted numeric tokens decode to JavaScript `number` values and follow IEEE 754 double-precision semantics. Finite values that exceed JavaScript's available precision may be rounded, including integers outside the safe integer range:
-
-```ts
-import { decode } from '@toon-format/toon'
-
-decode('unsafe: 9007199254740993')
-// { unsafe: 9007199254740992 }
-```
-
-Numeric tokens that overflow the finite `number` range decode as strings. If an exact high-precision value must survive decoding, emit it as a quoted string. The encoder follows this policy automatically for `BigInt` values outside the safe integer range:
-
-```ts
-import { decode, encode } from '@toon-format/toon'
-
-decode('exact: "9007199254740993"')
-// { exact: '9007199254740993' }
-
-decode(encode({ exact: 9007199254740993n }))
-// { exact: '9007199254740993' }
-```
+Numeric tokens decode to `number` and follow IEEE 754 double precision: values beyond it round silently (including integers outside the safe integer range), and tokens that overflow the finite range decode as strings – this is the decoder's documented out-of-range policy per [spec §4](https://github.com/toon-format/spec/blob/main/SPEC.md#4-decoding-interpretation-reference-decoder). Values that must stay exact belong in quoted strings; `encode()` writes out-of-range `BigInt` values that way automatically.
 
 #### Example
 

--- a/packages/toon/README.md
+++ b/packages/toon/README.md
@@ -751,6 +751,9 @@ pnpm add @toon-format/toon
 yarn add @toon-format/toon
 ```
 
+> [!NOTE]
+> Unquoted numeric tokens decode to JavaScript `number` values. They therefore follow IEEE 754 double-precision semantics and may be rounded when they exceed the precision JavaScript can represent, including integers outside the safe integer range. Numeric tokens that overflow the finite `number` range decode as strings. Emit exact high-precision values as quoted strings; `encode()` does this automatically for `BigInt` values outside the safe integer range.
+
 **Example usage:**
 
 ```ts

--- a/packages/toon/README.md
+++ b/packages/toon/README.md
@@ -751,9 +751,6 @@ pnpm add @toon-format/toon
 yarn add @toon-format/toon
 ```
 
-> [!NOTE]
-> Unquoted numeric tokens decode to JavaScript `number` values. They therefore follow IEEE 754 double-precision semantics and may be rounded when they exceed the precision JavaScript can represent, including integers outside the safe integer range. Numeric tokens that overflow the finite `number` range decode as strings. Emit exact high-precision values as quoted strings; `encode()` does this automatically for `BigInt` values outside the safe integer range.
-
 **Example usage:**
 
 ```ts


### PR DESCRIPTION
## summary

The TypeScript decoder maps finite unquoted numeric tokens to JavaScript `number`, so values beyond the available precision can round. The v4 spec permits that behavior when the implementation documents it, but users currently have no decoder policy to rely on.

This documents the behavior in the npm README and API reference. It also shows the observed unsafe integer result and the quoted string and `BigInt` paths for values that need to remain exact. There is no runtime behavior change.

Closes #329

## validation

- checked each example against the current numeric parser and `BigInt` normalization path
- `git diff --check`

The full workspace lint could not run locally because its dependency tree did not fit the checkout's remaining disk. GitHub CI will run the repository's authoritative checks.
