### PR TITLE
feat(benchmarks): add OrcaRouter as an OpenAI-compatible provider

### DIFF
--- a/benchmarks/.env.example
+++ b/benchmarks/.env.example
@@ -3,3 +3,6 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GOOGLE_GENERATIVE_AI_API_KEY=
 XAI_API_KEY=
+# Optional: OrcaRouter (https://www.orcarouter.ai), an OpenAI-compatible gateway
+# used by the `orcarouter/auto` entry in the MODELS array
+ORCAROUTER_API_KEY=

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -102,6 +102,13 @@ Answers are validated deterministically with type-aware comparison (`50000` = `$
    cp .env.example .env
    ```
 
+> [!TIP]
+> OrcaRouter (`orcarouter/auto`) is included as a ready-made entry. It is an
+> OpenAI-compatible gateway, so the benchmark wires it up with
+> `createOpenAI({ baseURL: 'https://api.orcarouter.ai/v1' })` (via the chat
+> completions endpoint) and reads its key from `ORCAROUTER_API_KEY` (see
+> [`src/evaluate.ts`](./src/evaluate.ts)).
+
 ### Usage
 
 ```bash

--- a/benchmarks/src/evaluate.ts
+++ b/benchmarks/src/evaluate.ts
@@ -1,12 +1,26 @@
 import type { LanguageModelV4, LanguageModelV4CallOptions } from '@ai-sdk/provider'
 import type { Format } from './formats.ts'
 import type { EvaluationResult, Question } from './types.ts'
+import process from 'node:process'
 import { anthropic } from '@ai-sdk/anthropic'
 import { google } from '@ai-sdk/google'
-import { openai } from '@ai-sdk/openai'
+import { createOpenAI, openai } from '@ai-sdk/openai'
 import { xai } from '@ai-sdk/xai'
 import { generateText } from 'ai'
 import { compareAnswers } from './normalize.ts'
+
+/**
+ * OrcaRouter is an OpenAI-compatible AI gateway: one endpoint that routes each
+ * request across many models and providers. Point the OpenAI provider at its
+ * base URL and use the `orcarouter/auto` model id to let the gateway grade and
+ * route every prompt. `.chat()` is used so requests go to `/chat/completions`,
+ * which OrcaRouter serves as plain OpenAI-compatible chat.
+ */
+const orcarouter = createOpenAI({
+  name: 'orcarouter',
+  baseURL: 'https://api.orcarouter.ai/v1',
+  apiKey: process.env.ORCAROUTER_API_KEY,
+})
 
 /** A model paired with its rate limit and lazy provider constructor. */
 export interface ModelDescriptor {
@@ -25,6 +39,8 @@ export const MODELS: ModelDescriptor[] = [
   { id: 'gemini-3.6-flash', rpm: 25, create: () => google('gemini-3.6-flash') },
   { id: 'gpt-5.4-nano', rpm: 50, create: () => openai('gpt-5.4-nano') },
   { id: 'grok-4.5', rpm: 25, reasoning: 'low', create: () => xai('grok-4.5') },
+  // OrcaRouter: OpenAI-compatible gateway, `orcarouter/auto` routes each prompt adaptively
+  { id: 'orcarouter/auto', rpm: 50, create: () => orcarouter.chat('orcarouter/auto') },
 ]
 
 export async function evaluateQuestion(


### PR DESCRIPTION
## What

The retrieval-accuracy benchmark's `MODELS` registry in `benchmarks/src/evaluate.ts` currently covers Anthropic, Google, OpenAI, and xAI. This adds **OrcaRouter** (`orcarouter/auto`) as a ready-made entry so TOON's token/accuracy numbers can be produced through an OpenAI-compatible AI gateway that routes every prompt across many models.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Mirroring how the existing `openai('gpt-5.4-nano')` entry is wired, the new entry builds the provider with `createOpenAI({ baseURL: 'https://api.orcarouter.ai/v1' })` (via the chat-completions endpoint) and reads `ORCAROUTER_API_KEY` from the environment, documented in `.env.example` and the benchmark setup notes.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Verification

- `tsc --noEmit` clean, `eslint .` clean, `vitest run` 767 tests pass (Node 24, same as CI)
- Live-tested `orcarouter/auto` through the actual `MODELS` registry entry with `ORCAROUTER_API_KEY` — real completion returned, answer matched ground truth

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
