### PR TITLE
fix(encode): normalize sparse array holes to null

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -63,6 +63,7 @@ Non-JSON-serializable values are normalized before encoding:
 | `BigInt` (within safe range) | Number |
 | `BigInt` (out of range) | Quoted decimal string (e.g., `"9007199254740993"`) |
 | `Date` | ISO string in quotes (e.g., `"2025-01-01T00:00:00.000Z"`) |
+| Sparse array | Array with empty slots normalized to `null` |
 | `Set` | Array of normalized values |
 | `Map` | Object with `String(key)` keys |
 | `undefined`, `function`, `symbol` | `null` |

--- a/packages/toon/src/encode/normalize.ts
+++ b/packages/toon/src/encode/normalize.ts
@@ -62,7 +62,7 @@ export function normalizeValue(value: unknown): JsonValue {
   }
 
   if (Array.isArray(value)) {
-    return value.map(normalizeValue)
+    return Array.from(value, normalizeValue)
   }
 
   if (value instanceof Set) {

--- a/packages/toon/test/normalization.test.ts
+++ b/packages/toon/test/normalization.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable test/prefer-lowercase-title */
 import type { EncodeReplacer } from '../src/index'
 import { describe, expect, it } from 'vitest'
-import { decode, encode } from '../src/index'
+import { decode, encode, encodeLines } from '../src/index'
 
 describe('JavaScript-specific type normalization', () => {
   describe('BigInt normalization', () => {
@@ -49,6 +49,23 @@ describe('JavaScript-specific type normalization', () => {
     it('converts empty Set to empty array', () => {
       const result = encode(new Set())
       expect(result).toBe('[]')
+    })
+  })
+
+  describe('sparse array normalization', () => {
+    it.each([
+      { name: 'a single hole', input: Object.assign([], { length: 1 }), expected: [null] },
+      { name: 'only holes', input: Object.assign([], { length: 3 }), expected: [null, null, null] },
+      { name: 'primitive elements', input: Object.assign([], { length: 3, 0: 1, 2: 3 }), expected: [1, null, 3] },
+      { name: 'object elements', input: Object.assign([], { length: 3, 0: { x: 1 }, 2: { x: 2 } }), expected: [{ x: 1 }, null, { x: 2 }] },
+      { name: 'array elements', input: Object.assign([], { length: 3, 0: [1], 2: [2] }), expected: [[1], null, [2]] },
+      { name: 'an object property', input: { items: Object.assign([], { length: 2 }) }, expected: { items: [null, null] } },
+      { name: 'a toJSON result', input: { toJSON: () => Object.assign([], { length: 2 }) }, expected: [null, null] },
+    ])('normalizes holes to null for $name', ({ input, expected }) => {
+      const encoded = encode(input)
+      expect(encoded).toBe(encode(expected))
+      expect(decode(encoded)).toEqual(expected)
+      expect([...encodeLines(input)].join('\n')).toBe(encoded)
     })
   })
 


### PR DESCRIPTION
## Linked Issue

No existing issue; searches for sparse arrays, array holes, and `normalizeValue` found no equivalent fix.

## Description

A sparse array such as `Object.assign([], { length: 3, 0: 1, 2: 3 })` currently encodes as `[3]: 1,,3` and decodes to `[1, "", 3]`. A single empty slot produces output that cannot be decoded, while sparse arrays containing objects or arrays can throw during encoding.

Normalize empty slots to `null`, consistent with the existing `undefined` mapping. The example now emits `[3]: 1,null,3` and round-trips to `[1, null, 3]`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

- Use `Array.from(value, normalizeValue)` so normalization visits empty slots; `Array.map` skipped them and left holes for later layout detection.
- Add seven regression cases covering all-hole arrays, primitive/object/array elements, nested properties, and `toJSON` results, checking `encode`, `decode`, and `encodeLines`.
- Document the sparse-array mapping in the API normalization table.

## SPEC Compliance

- [x] This PR implements/fixes spec compliance
- [x] Spec section(s) affected: §2 JSON data model/round-trip equality; §3 host-type normalization; Appendix E.2 JavaScript guidance.
- [x] Spec version: 4.1.1. The wire format is unchanged; empty slots use this implementation's existing `undefined` → `null` mapping.

## Testing

On base `f151a5d830d001bc244395b891183cba37e0d935`, the final regression tests fail **7/7**; with the fix, the same tests pass **7/7**.

- [x] All existing tests pass: `CI=true pnpm run test` — **767 passed** (709 library, 54 CLI, 4 benchmarks).
- [x] Added new tests for changes: `pnpm exec vitest run packages/toon/test/normalization.test.ts -t 'sparse array normalization'`.
- [x] Tests cover edge cases and spec compliance.

Also passed `pnpm run lint`, `pnpm run test:types`, `pnpm run build`, and 15 built-package round-trips across comma, tab, and pipe delimiters. Validation used pinned pnpm 11.17.0 with the frozen lockfile and Node.js 26.0.0 on macOS.

## Pre-submission Checklist

- [x] My code follows the project's coding standards
- [x] I have run code formatting/linting tools
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
- [x] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe migration path below)

## Additional Context

Three files changed, +20/-2 lines. No dependency, generated artifact, or public API changes.
